### PR TITLE
Prevent out of bounds panic when value size exceeds c.config.MaxEntrySize

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -103,6 +103,18 @@ func TestHashCollision(t *testing.T) {
 	assert.Nil(t, cachedValue)
 }
 
+func TestOverlyLargeValue(t *testing.T) {
+	cache := NewBigCache(Config{1, 5 * time.Second, 1, 5, true})
+
+	value := "valueeeeeeeeeeeeeeeeeeeeeeee"
+	err := cache.Set("Key", []byte(value))
+	assert.Error(t, err, "Specified entry with length 28 for key 'Key' exeeds maxEntrySize: 5")
+
+	cachedValue, err := cache.Get("Key")
+	assert.Error(t, err, "Entry \"Key\" not found")
+	assert.Equal(t, []byte(nil), cachedValue)
+}
+
 type mockedClock struct {
 	value int64
 }


### PR DESCRIPTION
```
panic: runtime error: slice bounds out of range

goroutine 17 [running, locked to thread]:
github.com/allegro/bigcache/queue.(*BytesQueue).allocateAdditionalMemory(0xc8200b6a08)
	/home/dolf/Projects/ClueGetter/src/github.com/allegro/bigcache/queue/bytes_queue.go:70 +0x512
github.com/allegro/bigcache/queue.(*BytesQueue).Push(0xc8200b6a08, 0xc821871300, 0x3b, 0x3b, 0xd)
	/home/dolf/Projects/ClueGetter/src/github.com/allegro/bigcache/queue/bytes_queue.go:54 +0x407
github.com/allegro/bigcache.(*BigCache).Set(0xc820072930, 0xc3abe0, 0xd, 0xc8217f56a0, 0x1c, 0x20)
	/home/dolf/Projects/ClueGetter/src/github.com/allegro/bigcache/bigcache.go:105 +0xb12
```