### PR TITLE
Handling values bigger than whole slice in bytes queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ config := bigcache.Config{
 		Shards: 1000,                       // number of shards
 		LifeWindow: 10 * time.Minute,       // time after which entry can be evicted
 		MaxEntriesInWindow: 1000 * 10 * 60, // rps * lifeWindow
-		MaxEntrySize: 500,                  // max entry size in bytes
+		MaxEntrySize: 500,                  // max entry size in bytes, used only in initial memory allocation
 		Verbose: true,                      // prints information about additional memory allocation
 	}
 

--- a/bigcache.go
+++ b/bigcache.go
@@ -71,7 +71,7 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 	}
 	if entryKey := readKeyFromEntry(wrappedEntry); key != entryKey {
 		if c.config.Verbose {
-			log.Printf("Collision detected. Both %q and %q has same hash %x", key, entryKey, hashedKey)
+			log.Printf("Collision detected. Both %q and %q have the same hash %x", key, entryKey, hashedKey)
 		}
 		return nil, notFound(key)
 	}

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -104,6 +104,38 @@ func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereTailIsBef
 	assert.Equal(t, []byte("ab"), pop(queue))
 }
 
+func TestAllocateAdditionalSpaceForValueBiggerThanInitQueue(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(11, false)
+
+	// when
+	queue.Push(make([]byte, 100))
+
+	// then
+	assert.Equal(t, make([]byte, 100), pop(queue))
+	assert.Equal(t, 222, queue.Capacity())
+}
+
+func TestAllocateAdditionalSpaceForValueBiggerThanQueue(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(21, false)
+
+	// when
+	queue.Push(make([]byte, 2))
+	queue.Push(make([]byte, 2))
+	queue.Push(make([]byte, 100))
+
+	// then
+	queue.Pop()
+	queue.Pop()
+	assert.Equal(t, make([]byte, 100), pop(queue))
+	assert.Equal(t, 242, queue.Capacity())
+}
+
 func TestPopWholeQueue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR fixes bug described in #1. It allows to set values bigger than currently allocated memory for cache.