### PR TITLE
Little optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ therefore entries (de)serialization in front of the cache will be needed in most
 ```go
 import "github.com/allegro/bigcache"
 
-cache := bigcache.NewBigCache(bigcache.DefaultConfig(10 * time.Minute))
+cache, error := bigcache.NewBigCache(bigcache.DefaultConfig(10 * time.Minute))
 
 cache.Set("my-unique-key", []byte("value"))
 
@@ -28,14 +28,14 @@ allocation can be avoided in that way.
 import "github.com/allegro/bigcache"
 
 config := bigcache.Config{
-		Shards: 1000,                       // number of shards
+		Shards: 1024,                       // number of shards (must be a power of 2)
 		LifeWindow: 10 * time.Minute,       // time after which entry can be evicted
 		MaxEntriesInWindow: 1000 * 10 * 60, // rps * lifeWindow
 		MaxEntrySize: 500,                  // max entry size in bytes, used only in initial memory allocation
 		Verbose: true,                      // prints information about additional memory allocation
 	}
 
-cache := bigcache.NewBigCache(config)
+cache, error := bigcache.NewBigCache(config)
 
 cache.Set("my-unique-key", []byte("value"))
 

--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -15,32 +15,32 @@ func BenchmarkWriteToCacheWith1Shard(b *testing.B) {
 	writeToCache(b, 1, 100*time.Second, b.N)
 }
 
-func BenchmarkWriteToCacheWith500Shards(b *testing.B) {
-	writeToCache(b, 500, 100*time.Second, b.N)
+func BenchmarkWriteToCacheWith512Shards(b *testing.B) {
+	writeToCache(b, 512, 100*time.Second, b.N)
 }
 
-func BenchmarkWriteToCacheWith1kShards(b *testing.B) {
-	writeToCache(b, 1000, 100*time.Second, b.N)
+func BenchmarkWriteToCacheWith1024Shards(b *testing.B) {
+	writeToCache(b, 1024, 100*time.Second, b.N)
 }
 
-func BenchmarkWriteToCacheWith10kShards(b *testing.B) {
-	writeToCache(b, 10000, 100*time.Second, b.N)
+func BenchmarkWriteToCacheWith8192Shards(b *testing.B) {
+	writeToCache(b, 8192, 100*time.Second, b.N)
 }
 
-func BenchmarkWriteToCacheWith1kShardsAndSmallShardInitSize(b *testing.B) {
-	writeToCache(b, 1000, 100*time.Second, 100)
+func BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize(b *testing.B) {
+	writeToCache(b, 1024, 100*time.Second, 100)
 }
 
-func BenchmarkReadFromCacheWith1kShards(b *testing.B) {
-	readFromCache(b, 1000)
+func BenchmarkReadFromCacheWith1024Shards(b *testing.B) {
+	readFromCache(b, 1024)
 }
 
-func BenchmarkReadFromCacheWith10kShards(b *testing.B) {
-	readFromCache(b, 10000)
+func BenchmarkReadFromCacheWith8192Shards(b *testing.B) {
+	readFromCache(b, 8192)
 }
 
 func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsInLifeWindow int) {
-	cache := NewBigCache(Config{shards, lifeWindow, max(requestsInLifeWindow, 100), 500, false})
+	cache, _ := NewBigCache(Config{shards, lifeWindow, max(requestsInLifeWindow, 100), 500, false, nil})
 	rand.Seed(time.Now().Unix())
 
 	b.RunParallel(func(pb *testing.PB) {
@@ -54,7 +54,7 @@ func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsIn
 }
 
 func readFromCache(b *testing.B, shards int) {
-	cache := NewBigCache(Config{10000, 1000 * time.Second, max(b.N, 100), 500, false})
+	cache, _ := NewBigCache(Config{8192, 1000 * time.Second, max(b.N, 100), 500, false, nil})
 	for i := 0; i < b.N; i++ {
 		cache.Set(strconv.Itoa(i), message)
 	}

--- a/caches_bench/caches_bench_test.go
+++ b/caches_bench/caches_bench_test.go
@@ -150,11 +150,13 @@ func parallelKey(threadID int, counter int) string {
 }
 
 func initBigCache(entriesInWindow int) *bigcache.BigCache {
-	return bigcache.NewBigCache(bigcache.Config{
+	cache, _ := bigcache.NewBigCache(bigcache.Config{
 		Shards:             256,
 		LifeWindow:         10 * time.Minute,
 		MaxEntriesInWindow: entriesInWindow,
 		MaxEntrySize:       maxEntrySize,
 		Verbose:            true,
 	})
+
+	return cache
 }

--- a/caches_bench/caches_gc_overhead_comparsion.go
+++ b/caches_bench/caches_gc_overhead_comparsion.go
@@ -27,14 +27,14 @@ func main() {
 	fmt.Println("Number of entries: ", entries)
 
 	config := bigcache.Config{
-		Shards:             250,
+		Shards:             256,
 		LifeWindow:         100 * time.Minute,
 		MaxEntriesInWindow: entries,
 		MaxEntrySize:       200,
 		Verbose:            true,
 	}
 
-	bigcache := bigcache.NewBigCache(config)
+	bigcache, _ := bigcache.NewBigCache(config)
 	for i := 0; i < entries; i++ {
 		key, val := generateKeyValue(i, valueSize)
 		bigcache.Set(key, val)

--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import "time"
 // Config for BigCache
 type Config struct {
 	// Number of cache shards
+	// Proper value must be a power of two
 	Shards int
 	// Time after which entry can be evicted
 	LifeWindow time.Duration
@@ -15,16 +16,19 @@ type Config struct {
 	MaxEntrySize int
 	// Verbose mode prints information about new memory allocation
 	Verbose bool
+	// Hasher used to map between string keys and unsigned 64bit integers, by default fnv64 hashing is used.
+	Hasher Hasher
 }
 
 // DefaultConfig initializes config with default values.
 // When load for BigCache can be predicted in advance then it is better to use custom config.
 func DefaultConfig(eviction time.Duration) Config {
 	return Config{
-		Shards:             1000,
+		Shards:             1024,
 		LifeWindow:         eviction,
 		MaxEntriesInWindow: 1000 * 10 * 60,
 		MaxEntrySize:       500,
 		Verbose:            true,
+		Hasher:             newDefaultHasher(),
 	}
 }

--- a/hash.go
+++ b/hash.go
@@ -1,15 +1,24 @@
 package bigcache
 
-import "hash/fnv"
+import (
+	"hash/fnv"
+)
 
-type hash interface {
-	sum(string) uint64
+// Hasher is responsible for generating unsigned, 64 bit hash of provided string. Hasher should minimize collisions
+// (generating same hash for different strings) and while performance is also important fast functions are preferable (i.e.
+// you can use FarmHash family).
+type Hasher interface {
+	Sum64(string) uint64
+}
+
+func newDefaultHasher() Hasher {
+	return fnv64a{}
 }
 
 type fnv64a struct {
 }
 
-func (f fnv64a) sum(key string) uint64 {
+func (f fnv64a) Sum64(key string) uint64 {
 	h := fnv.New64a()
 	h.Write([]byte(key))
 	return h.Sum64()

--- a/hash_test.go
+++ b/hash_test.go
@@ -2,6 +2,6 @@ package bigcache
 
 type hashStub uint64
 
-func (stub hashStub) sum(_ string) uint64 {
+func (stub hashStub) Sum64(_ string) uint64 {
 	return uint64(stub)
 }


### PR DESCRIPTION
Hi,

I've applied two optimizations to bigcache:

- provided ability to use other hash functions like [farmhash](http://www.infoq.com/news/2014/04/google_farmhash) instead of fnv
- ensured that number of shards is power of two thus eliminating modulo operation in favor of bit mask

Results aggregated across 10 runs (before optimizations - with changes to number of shards in test cases):

```
BenchmarkWriteToCacheWith1Shard-8                           	1088 ns/op
BenchmarkWriteToCacheWith512Shards-8                        	342 ns/op
BenchmarkWriteToCacheWith1024Shards-8                       	342 ns/op
BenchmarkWriteToCacheWith8192Shards-8                       	359 ns/op
BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize-8  	427 ns/op
BenchmarkReadFromCacheWith1024Shards-8                      	207 ns/op
BenchmarkReadFromCacheWith8192kShards-8                     	206 ns/op
```

Results aggregated across 10 runs (after optimizations):
```
BenchmarkWriteToCacheWith1Shard-8                           	1006 ns/op
BenchmarkWriteToCacheWith512Shards-8                        	331 ns/op
BenchmarkWriteToCacheWith1024Shards-8                       	316 ns/op
BenchmarkWriteToCacheWith8192Shards-8                       	326 ns/op
BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize-8  	393 ns/op
BenchmarkReadFromCacheWith1024Shards-8                      	207 ns/op
BenchmarkReadFromCacheWith8192Shards-8                      	203 ns/op
```

