### PR TITLE
Wrap entry optimization

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -11,17 +11,22 @@ const (
 	headersSizeInBytes   = timestampSizeInBytes + hashSizeInBytes + keySizeInBytes // Number of bytes used for all headers
 )
 
-func wrapEntry(timestamp uint64, hash uint64, key string, entry []byte) []byte {
-	var blob []byte
+func wrapEntry(timestamp uint64, hash uint64, key string, entry []byte, buffer *[]byte) []byte {
 	keyLength := len(key)
-	blob = make([]byte, len(entry)+headersSizeInBytes+keyLength)
+	blobLength := len(entry) + headersSizeInBytes + keyLength
+
+	if blobLength > len(*buffer) {
+		*buffer = make([]byte, blobLength)
+	}
+	blob := *buffer
+
 	binary.LittleEndian.PutUint64(blob, timestamp)
 	binary.LittleEndian.PutUint64(blob[timestampSizeInBytes:], hash)
 	binary.LittleEndian.PutUint16(blob[timestampSizeInBytes+hashSizeInBytes:], uint16(keyLength))
 	copy(blob[headersSizeInBytes:], []byte(key))
 	copy(blob[headersSizeInBytes+keyLength:], entry)
 
-	return blob
+	return blob[:blobLength]
 }
 
 func readEntry(data []byte) []byte {

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -13,13 +13,34 @@ func TestEncodeDecode(t *testing.T) {
 	hash := uint64(42)
 	key := "key"
 	data := []byte("data")
+	buffer := make([]byte, 100)
 
 	// when
-	wrapped := wrapEntry(now, hash, key, data)
+	wrapped := wrapEntry(now, hash, key, data, &buffer)
 
 	// then
 	assert.Equal(t, key, readKeyFromEntry(wrapped))
 	assert.Equal(t, hash, readHashFromEntry(wrapped))
 	assert.Equal(t, now, readTimestampFromEntry(wrapped))
 	assert.Equal(t, data, readEntry(wrapped))
+	assert.Equal(t, 100, len(buffer))
+}
+
+func TestAllocateBiggerBuffer(t *testing.T) {
+	//given
+	now := uint64(time.Now().Unix())
+	hash := uint64(42)
+	key := "1"
+	data := []byte("2")
+	buffer := make([]byte, 1)
+
+	// when
+	wrapped := wrapEntry(now, hash, key, data, &buffer)
+
+	// then
+	assert.Equal(t, key, readKeyFromEntry(wrapped))
+	assert.Equal(t, hash, readHashFromEntry(wrapped))
+	assert.Equal(t, now, readTimestampFromEntry(wrapped))
+	assert.Equal(t, data, readEntry(wrapped))
+	assert.Equal(t, 2+headersSizeInBytes, len(buffer))
 }


### PR DESCRIPTION
Alternative implementation of wrap entry optimization proposed by @wendigo in #5 

Instead of using global sync.Pool with locks, entry byte buffer is allocated per shard.

Bench test results before and after optimization:

```
go test -bench=WriteToCacheWith -benchtime=5s

BenchmarkWriteToCacheWith1Shard-4                       5000000	     1520 ns/op
BenchmarkWriteToCacheWith500Shards-4                    	10000000	      647 ns/op
BenchmarkWriteToCacheWith1kShards-4                     10000000	      627 ns/op
BenchmarkWriteToCacheWith10kShards-4                    	10000000	      646 ns/op
BenchmarkWriteToCacheWith1kShardsAndSmallShardInitSize-4	10000000	      789 ns/op

BenchmarkWriteToCacheWith1Shard-4                       5000000	     1320 ns/op
BenchmarkWriteToCacheWith500Shards-4                    	20000000	      594 ns/op
BenchmarkWriteToCacheWith1kShards-4                     20000000	      616 ns/op
BenchmarkWriteToCacheWith10kShards-4                    	10000000	      629 ns/op
BenchmarkWriteToCacheWith1kShardsAndSmallShardInitSize-4	10000000	      717 ns/op
```

Total time spent on entries wrapping during bench tests:

```
//before opt
1.13s     15.34s    104:	w := wrapEntry(currentTimestamp, hashedKey, key, entry)

//after opt
2.50s      3.84s    106:	w := wrapEntry(currentTimestamp, hashedKey, key, entry, &shard.entryBuffer)
```