### PR TITLE
Entries indexes stay unchanged after additional memory allocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ When cache load can be predicted in advance then it is better to use custom init
 allocation can be avoided in that way.
 
 ```go
-import "github.com/allegro/bigcache"
+import (
+	"log"
+
+	"github.com/allegro/bigcache"
+)
 
 config := bigcache.Config{
 		Shards: 1024,                       // number of shards (must be a power of 2)
@@ -35,7 +39,10 @@ config := bigcache.Config{
 		Verbose: true,                      // prints information about additional memory allocation
 	}
 
-cache, error := bigcache.NewBigCache(config)
+cache, initErr := bigcache.NewBigCache(config)
+if initErr != nil {
+	log.Fatal(initErr)
+}
 
 cache.Set("my-unique-key", []byte("value"))
 

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -40,17 +40,17 @@ func TestReuseAvailableSpace(t *testing.T) {
 	t.Parallel()
 
 	// given
-	queue := NewBytesQueue(21, false)
+	queue := NewBytesQueue(100, false)
 
 	// when
-	queue.Push([]byte("hello1"))
-	queue.Push([]byte("hello2"))
+	queue.Push(blob('a', 70))
+	queue.Push(blob('b', 20))
 	queue.Pop()
-	queue.Push([]byte("hello3"))
+	queue.Push(blob('c', 20))
 
 	// then
-	assert.Equal(t, 21, queue.Capacity())
-	assert.Equal(t, []byte("hello2"), pop(queue))
+	assert.Equal(t, 100, queue.Capacity())
+	assert.Equal(t, blob('b', 20), pop(queue))
 }
 
 func TestAllocateAdditionalSpace(t *testing.T) {
@@ -71,37 +71,79 @@ func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereHeadIsBef
 	t.Parallel()
 
 	// given
-	queue := NewBytesQueue(21, false)
+	queue := NewBytesQueue(25, false)
 
 	// when
-	queue.Push([]byte("msg"))    // header + msg = 7bytes
-	queue.Push([]byte("hello1")) // 10 bytes
-	queue.Pop()                  // space freed, 13 bytes available
-	queue.Push([]byte("toobig")) // 10 bytes needed, 13 available but not in one segment, allocate additional memory
+	queue.Push(blob('a', 3)) // header + entry + left margin = 8 bytes
+	queue.Push(blob('b', 6)) // additional 10 bytes
+	queue.Pop()              // space freed, 7 bytes available at the beginning
+	queue.Push(blob('c', 6)) // 10 bytes needed, 14 available but not in one segment, allocate additional memory
 
 	// then
-	assert.Equal(t, 42, queue.Capacity())
-	assert.Equal(t, []byte("hello1"), pop(queue))
+	assert.Equal(t, 50, queue.Capacity())
+	assert.Equal(t, blob('b', 6), pop(queue))
+	assert.Equal(t, blob('c', 6), pop(queue))
+}
+
+func TestUnchangedEntriesIndexesAfterAdditionalMemoryAllocationWhereHeadIsBeforeTail(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(25, false)
+
+	// when
+	queue.Push(blob('a', 3))                // header + entry + left margin = 8 bytes
+	index := queue.Push(blob('b', 6))       // additional 10 bytes
+	queue.Pop()                             // space freed, 7 bytes available at the beginning
+	newestIndex := queue.Push(blob('c', 6)) // 10 bytes needed, 14 available but not in one segment, allocate additional memory
+
+	// then
+	assert.Equal(t, 50, queue.Capacity())
+	assert.Equal(t, blob('b', 6), get(queue, index))
+	assert.Equal(t, blob('c', 6), get(queue, newestIndex))
 }
 
 func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereTailIsBeforeHead(t *testing.T) {
 	t.Parallel()
 
 	// given
-	queue := NewBytesQueue(21, false)
+	queue := NewBytesQueue(100, false)
 
 	// when
-	queue.Push([]byte("hello1")) // header + msg = 10 bytes
-	queue.Push([]byte("msg"))    // 7 bytes
-	queue.Pop()                  // 13 bytes available - 10 at the beginning and 3 at the end (right margin)
-	queue.Push([]byte("a"))      // 5 bytes used at the beginning, tail pointer is before head pointer
-	queue.Push([]byte("ab"))     // 6 bytes needed but no available in one segment, allocate new memory
+	queue.Push(blob('a', 70)) // header + entry + left margin = 75 bytes
+	queue.Push(blob('b', 10)) // 75 + 10 + 4 = 89 bytes
+	queue.Pop()               // space freed at the beginning
+	queue.Push(blob('c', 30)) // 34 bytes used at the beginning, tail pointer is before head pointer
+	queue.Push(blob('d', 40)) // 44 bytes needed but no available in one segment, allocate new memory
 
 	// then
-	assert.Equal(t, 42, queue.Capacity())
-	assert.Equal(t, []byte("msg"), pop(queue))
-	assert.Equal(t, []byte("a"), pop(queue))
-	assert.Equal(t, []byte("ab"), pop(queue))
+	assert.Equal(t, 200, queue.Capacity())
+	assert.Equal(t, blob('c', 30), pop(queue))
+	// empty blob fills space between tail and head,
+	// created when additional memory was allocated,
+	// it keeps current entries indexes unchanged
+	assert.Equal(t, blob(0, 36), pop(queue))
+	assert.Equal(t, blob('b', 10), pop(queue))
+	assert.Equal(t, blob('d', 40), pop(queue))
+}
+
+func TestUnchangedEntriesIndexesAfterAdditionalMemoryAllocationWhereTailIsBeforeHead(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(100, false)
+
+	// when
+	queue.Push(blob('a', 70))                // header + entry + left margin = 75 bytes
+	index := queue.Push(blob('b', 10))       // 75 + 10 + 4 = 89 bytes
+	queue.Pop()                              // space freed at the beginning
+	queue.Push(blob('c', 30))                // 34 bytes used at the beginning, tail pointer is before head pointer
+	newestIndex := queue.Push(blob('d', 40)) // 44 bytes needed but no available in one segment, allocate new memory
+
+	// then
+	assert.Equal(t, 200, queue.Capacity())
+	assert.Equal(t, blob('b', 10), get(queue, index))
+	assert.Equal(t, blob('d', 40), get(queue, newestIndex))
 }
 
 func TestAllocateAdditionalSpaceForValueBiggerThanInitQueue(t *testing.T) {
@@ -111,10 +153,10 @@ func TestAllocateAdditionalSpaceForValueBiggerThanInitQueue(t *testing.T) {
 	queue := NewBytesQueue(11, false)
 
 	// when
-	queue.Push(make([]byte, 100))
+	queue.Push(blob('a', 100))
 
 	// then
-	assert.Equal(t, make([]byte, 100), pop(queue))
+	assert.Equal(t, blob('a', 100), pop(queue))
 	assert.Equal(t, 222, queue.Capacity())
 }
 
@@ -187,4 +229,17 @@ func TestGetEntryFromInvalidIndex(t *testing.T) {
 func pop(queue *BytesQueue) []byte {
 	entry, _ := queue.Pop()
 	return entry
+}
+
+func get(queue *BytesQueue, index int) []byte {
+	entry, _ := queue.Get(index)
+	return entry
+}
+
+func blob(char byte, len int) []byte {
+	b := make([]byte, len)
+	for index := range b {
+		b[index] = char
+	}
+	return b
 }


### PR DESCRIPTION
When additional memory allocation occurs in bytes queue then its entries indexes should stay unchanged, because  values from bigcache map can point to them. Proposed fix fills space between tail and head pointers with an empty blob, unit tests show how bytes queue behaves in that situation.