### PR TITLE
Build only for go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 go:
   - 1.6
-  - tip
 
 before_install:
   - go get github.com/modocache/gover


### PR DESCRIPTION
Because our builds starts to fail due to problems with third party tools on go 1.7 we want to run build only on stable releases.