### PR TITLE
Improve fnv64a hashing algorithm by remove all allocations

### DIFF
--- a/fnv.go
+++ b/fnv.go
@@ -1,0 +1,28 @@
+package bigcache
+
+// newDefaultHasher returns a new 64-bit FNV-1a Hasher which makes no memory allocations.
+// Its Sum64 method will lay the value out in big-endian byte order.
+// See https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function
+func newDefaultHasher() Hasher {
+	return fnv64a{}
+}
+
+type fnv64a struct{}
+
+const (
+	// offset64 FNVa offset basis. See https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function#FNV-1a_hash
+	offset64 = 14695981039346656037
+	// prime64 FNVa prime value. See https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function#FNV-1a_hash
+	prime64 = 1099511628211
+)
+
+// Sum64 gets the string and returns its uint64 hash value.
+func (f fnv64a) Sum64(key string) uint64 {
+	var hash uint64 = offset64
+	for i := 0; i < len(key); i++ {
+		hash ^= uint64(key[i])
+		hash *= prime64
+	}
+
+	return hash
+}

--- a/fnv_bench_test.go
+++ b/fnv_bench_test.go
@@ -1,0 +1,18 @@
+package bigcache
+
+import "testing"
+
+var text = "abcdefg"
+
+func BenchmarkFnvHashSum64(b *testing.B) {
+	h := newDefaultHasher()
+	for i := 0; i < b.N; i++ {
+		h.Sum64(text)
+	}
+}
+
+func BenchmarkFnvHashStdLibSum64(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		stdLibFnvSum64(text)
+	}
+}

--- a/fnv_test.go
+++ b/fnv_test.go
@@ -1,0 +1,35 @@
+package bigcache
+
+import (
+	"hash/fnv"
+	"testing"
+)
+
+type testCase struct {
+	text         string
+	expectedHash uint64
+}
+
+var testCases = []testCase{
+	{"", stdLibFnvSum64("")},
+	{"a", stdLibFnvSum64("a")},
+	{"ab", stdLibFnvSum64("ab")},
+	{"abc", stdLibFnvSum64("abc")},
+	{"some longer and more complicated text", stdLibFnvSum64("some longer and more complicated text")},
+}
+
+func TestFnvHashSum64(t *testing.T) {
+	h := newDefaultHasher()
+	for _, testCase := range testCases {
+		hashed := h.Sum64(testCase.text)
+		if hashed != testCase.expectedHash {
+			t.Errorf("hash(%q) = %d want %d", testCase.text, hashed, testCase.expectedHash)
+		}
+	}
+}
+
+func stdLibFnvSum64(key string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(key))
+	return h.Sum64()
+}

--- a/hash.go
+++ b/hash.go
@@ -1,25 +1,8 @@
 package bigcache
 
-import (
-	"hash/fnv"
-)
-
 // Hasher is responsible for generating unsigned, 64 bit hash of provided string. Hasher should minimize collisions
 // (generating same hash for different strings) and while performance is also important fast functions are preferable (i.e.
 // you can use FarmHash family).
 type Hasher interface {
 	Sum64(string) uint64
-}
-
-func newDefaultHasher() Hasher {
-	return fnv64a{}
-}
-
-type fnv64a struct {
-}
-
-func (f fnv64a) Sum64(key string) uint64 {
-	h := fnv.New64a()
-	h.Write([]byte(key))
-	return h.Sum64()
 }


### PR DESCRIPTION
Hi everyone,

Lastly I've seen 2 great tutorial how to profile and optimize Go programs. Based on that knowledge I found some small improvements in your bigcache package. I started from adding allocation reporting for all of your benchmarks. After further analysis in pprof tool it showed me that your usage of fnv64a hash function was a bit inefficient. There were 2 not necessary allocations. Here is the output of your benchmarks before the changes:

> BenchmarkWriteToCacheWith1Shard-4                            	 2000000	       963 ns/op	     617 B/op	       5 allocs/op
> BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard-4     	 2000000	       828 ns/op	      65 B/op	       4 allocs/op
> BenchmarkWriteToUnlimitedCacheWithSmallInitSizeAnd1Shard-4   	 1000000	      1591 ns/op	    3470 B/op	       4 allocs/op
> BenchmarkWriteToCacheWith512Shards-4                         	 3000000	       540 ns/op	     611 B/op	       5 allocs/op
> BenchmarkWriteToCacheWith1024Shards-4                        	 3000000	       537 ns/op	     611 B/op	       5 allocs/op
> BenchmarkWriteToCacheWith8192Shards-4                        	 2000000	       581 ns/op	     628 B/op	       5 allocs/op
> BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize-4   	 2000000	       642 ns/op	     823 B/op	       5 allocs/op
> BenchmarkReadFromCacheWith1024Shards-4                       	 5000000	       283 ns/op	      31 B/op	       4 allocs/op
> BenchmarkReadFromCacheWith8192Shards-4                       	 5000000	       283 ns/op	      31 B/op	       4 allocs/op
> PASS
> ok  	github.com/allegro/bigcache	28.775s

Benchmark results after my changes:

> BenchmarkWriteToCacheWith1Shard-4                            	 2000000	       886 ns/op	     577 B/op	       3 allocs/op
BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard-4     	 2000000	       761 ns/op	      41 B/op	       2 allocs/op
BenchmarkWriteToUnlimitedCacheWithSmallInitSizeAnd1Shard-4   	 1000000	      1545 ns/op	    3446 B/op	       2 allocs/op
BenchmarkWriteToCacheWith512Shards-4                         	 3000000	       495 ns/op	     571 B/op	       3 allocs/op
BenchmarkWriteToCacheWith1024Shards-4                        	 3000000	       501 ns/op	     571 B/op	       3 allocs/op
BenchmarkWriteToCacheWith8192Shards-4                        	 3000000	       533 ns/op	     590 B/op	       3 allocs/op
BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize-4   	 3000000	       614 ns/op	     979 B/op	       3 allocs/op
BenchmarkReadFromCacheWith1024Shards-4                       	 5000000	       261 ns/op	      15 B/op	       2 allocs/op
BenchmarkReadFromCacheWith8192Shards-4                       	 5000000	       248 ns/op	      15 B/op	       2 allocs/op
PASS
ok  	github.com/allegro/bigcache	28.084s


And comparison taken from benchcmp tool(https://godoc.org/golang.org/x/tools/cmd/benchcmp):

> benchmark                                                      old ns/op     new ns/op     delta
BenchmarkWriteToCacheWith1Shard-4                              963           886           -8.00%
BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard-4       828           761           -8.09%
BenchmarkWriteToUnlimitedCacheWithSmallInitSizeAnd1Shard-4     1591          1545          -2.89%
BenchmarkWriteToCacheWith512Shards-4                           540           495           -8.33%
BenchmarkWriteToCacheWith1024Shards-4                          537           501           -6.70%
BenchmarkWriteToCacheWith8192Shards-4                          581           533           -8.26%
BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize-4     642           614           -4.36%
BenchmarkReadFromCacheWith1024Shards-4                         283           261           -7.77%
BenchmarkReadFromCacheWith8192Shards-4                         283           248           -12.37%

> benchmark                                                      old allocs     new allocs     delta
BenchmarkWriteToCacheWith1Shard-4                              5              3              -40.00%
BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard-4       4              2              -50.00%
BenchmarkWriteToUnlimitedCacheWithSmallInitSizeAnd1Shard-4     4              2              -50.00%
BenchmarkWriteToCacheWith512Shards-4                           5              3              -40.00%
BenchmarkWriteToCacheWith1024Shards-4                          5              3              -40.00%
BenchmarkWriteToCacheWith8192Shards-4                          5              3              -40.00%
BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize-4     5              3              -40.00%
BenchmarkReadFromCacheWith1024Shards-4                         4              2              -50.00%
BenchmarkReadFromCacheWith8192Shards-4                         4              2              -50.00%


I've tested it against Go1.6.2 and 1.7beta1. On both versions results were better between 2-12% in ns/op. Less number of allocations should also improve the GC pauses. 

The problem was that you have called fnv.New64a() every time. Under the hood it allocates bytes and it could be omit. One solution might be sync.Pool but it's not reliable in case of GC. Another is just take the Go standard library fnv64a implementation and remove the allocation which is made in New64a func. 

Inspiration for this PR:
https://youtu.be/ZuQcbqYK0BY 
https://youtu.be/N3PWzBeLX2M