### PR TITLE
Zero alloc byte to string conversion

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -134,6 +134,26 @@ func TestOldestEntryDeletionWhenMaxCacheSizeIsReached(t *testing.T) {
 	assert.Equal(t, blob('c', 1024*800), entry3)
 }
 
+func TestRetrievingEntryShouldCopy(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1, nil})
+	cache.Set("key1", blob('a', 1024*400))
+	value, key1Err := cache.Get("key1")
+
+	// when
+	// override queue
+	cache.Set("key2", blob('b', 1024*400))
+	cache.Set("key3", blob('c', 1024*400))
+	cache.Set("key4", blob('d', 1024*400))
+	cache.Set("key5", blob('d', 1024*400))
+
+	// then
+	assert.Nil(t, key1Err)
+	assert.Equal(t, blob('a', 1024*400), value)
+}
+
 func TestEntryBiggerThanMaxShardSizeError(t *testing.T) {
 	t.Parallel()
 

--- a/encoding.go
+++ b/encoding.go
@@ -2,6 +2,8 @@ package bigcache
 
 import (
 	"encoding/binary"
+	"reflect"
+	"unsafe"
 )
 
 const (
@@ -40,7 +42,13 @@ func readTimestampFromEntry(data []byte) uint64 {
 
 func readKeyFromEntry(data []byte) string {
 	length := binary.LittleEndian.Uint16(data[timestampSizeInBytes+hashSizeInBytes:])
-	return string(data[headersSizeInBytes : headersSizeInBytes+length])
+	return bytesToString(data[headersSizeInBytes : headersSizeInBytes+length])
+}
+
+func bytesToString(b []byte) string {
+	bytesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
+	strHeader := reflect.StringHeader{Data: bytesHeader.Data, Len: bytesHeader.Len}
+	return *(*string)(unsafe.Pointer(&strHeader))
 }
 
 func readHashFromEntry(data []byte) uint64 {

--- a/encoding.go
+++ b/encoding.go
@@ -25,7 +25,7 @@ func wrapEntry(timestamp uint64, hash uint64, key string, entry []byte, buffer *
 	binary.LittleEndian.PutUint64(blob, timestamp)
 	binary.LittleEndian.PutUint64(blob[timestampSizeInBytes:], hash)
 	binary.LittleEndian.PutUint16(blob[timestampSizeInBytes+hashSizeInBytes:], uint16(keyLength))
-	copy(blob[headersSizeInBytes:], []byte(key))
+	copy(blob[headersSizeInBytes:], stringToBytes(key))
 	copy(blob[headersSizeInBytes+keyLength:], entry)
 
 	return blob[:blobLength]
@@ -49,6 +49,11 @@ func bytesToString(b []byte) string {
 	bytesHeader := (*reflect.SliceHeader)(unsafe.Pointer(&b))
 	strHeader := reflect.StringHeader{Data: bytesHeader.Data, Len: bytesHeader.Len}
 	return *(*string)(unsafe.Pointer(&strHeader))
+}
+
+func stringToBytes(s string) []byte {
+	sliceHeader := (*reflect.SliceHeader)(unsafe.Pointer(&s))
+	return *(*[]byte)(unsafe.Pointer(sliceHeader))
 }
 
 func readHashFromEntry(data []byte) uint64 {

--- a/iterator.go
+++ b/iterator.go
@@ -17,6 +17,8 @@ const ErrInvalidIteratorState = iteratorError("Iterator is in invalid state. Use
 // ErrCannotRetrieveEntry is reported when entry cannot be retrieved from underlying
 var ErrCannotRetrieveEntry = errors.New("Could not retrieve entry from cache")
 
+var emptyEntryInfo = EntryInfo{}
+
 // EntryInfo holds informations about entry in the cache
 type EntryInfo struct {
 	timestamp uint64
@@ -117,13 +119,13 @@ func (it *EntryInfoIterator) Value() (EntryInfo, error) {
 	defer it.Unlock()
 
 	if !it.valid {
-		return EntryInfo{}, ErrInvalidIteratorState
+		return emptyEntryInfo, ErrInvalidIteratorState
 	}
 
 	entry, err := it.cache.shards[it.currentShard].entries.Get(int(it.elements[it.currentIndex]))
 
 	if err != nil {
-		return EntryInfo{}, ErrCannotRetrieveEntry
+		return emptyEntryInfo, ErrCannotRetrieveEntry
 	}
 
 	return EntryInfo{


### PR DESCRIPTION
No copying when converting []byte to string.

```
go test -bench BenchmarkIterateOverCache -memprofile mem.out
2016/11/03 00:29:24 Collision detected. Both "liquid" and "costarring" have the same hash 5
BenchmarkIterateOverCache/512-shards-8         	 5000000	       397 ns/op	       4 B/op	       0 allocs/op
BenchmarkIterateOverCache/1024-shards-8        	 5000000	       398 ns/op	       4 B/op	       0 allocs/op
BenchmarkIterateOverCache/8192-shards-8        	 5000000	       374 ns/op	       4 B/op	       0 allocs/op
```

Also we should use []byte keys instead of strings...