### PR TITLE
Changed locking strategy

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -70,11 +70,13 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 	itemIndex := shard.hashmap[hashedKey]
 
 	if itemIndex == 0 {
+		shard.lock.RUnlock()
 		return nil, notFound(key)
 	}
 
 	wrappedEntry, err := shard.entries.Get(int(itemIndex))
 	if err != nil {
+		shard.lock.RUnlock()
 		return nil, err
 	}
 	if entryKey := readKeyFromEntry(wrappedEntry); key != entryKey {
@@ -84,6 +86,7 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 		shard.lock.RUnlock()
 		return nil, notFound(key)
 	}
+	shard.lock.RUnlock()
 	return readEntry(wrappedEntry), nil
 }
 

--- a/bigcache.go
+++ b/bigcache.go
@@ -66,7 +66,6 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 	hashedKey := c.hash.Sum64(key)
 	shard := c.getShard(hashedKey)
 	shard.lock.RLock()
-	defer shard.lock.RUnlock()
 
 	itemIndex := shard.hashmap[hashedKey]
 

--- a/iterator.go
+++ b/iterator.go
@@ -57,7 +57,6 @@ type EntryInfoIterator struct {
 
 func copyCurrentShardMap(shard *cacheShard) ([]uint32, int) {
 	shard.lock.RLock()
-	defer shard.lock.RUnlock()
 
 	var elements = make([]uint32, len(shard.hashmap))
 	next := 0
@@ -67,6 +66,7 @@ func copyCurrentShardMap(shard *cacheShard) ([]uint32, int) {
 		next++
 	}
 
+	shard.lock.RUnlock()
 	return elements, next
 }
 

--- a/shard.go
+++ b/shard.go
@@ -29,11 +29,12 @@ func (s *cacheShard) removeOldestEntry() error {
 
 func (s *cacheShard) reset(config Config) {
 	s.lock.Lock()
-	defer s.lock.Unlock()
 
 	s.hashmap = make(map[uint64]uint32, config.initialShardSize())
 	s.entryBuffer = make([]byte, config.MaxEntrySize+headersSizeInBytes)
 	s.entries.Reset()
+
+	s.lock.Unlock()
 }
 
 func (s *cacheShard) len() int {


### PR DESCRIPTION
There is a known issue in Go with deferred operations being much slower than explicit operations, both directly and indirectly impacting locking.

Here are the performance comparisons (from benchstat) over 1000 iterations:

```
name                   old time/op    new time/op    delta
BigCacheSet-8             569ns ± 6%     511ns ± 5%  -10.24%  (p=0.000 n=860+949)
BigCacheGet-8             525ns ± 3%     454ns ± 5%  -13.45%  (p=0.000 n=922+930)
BigCacheSetParallel-8     178ns ± 2%     164ns ±20%   -7.61%  (p=0.000 n=961+804)
```

I did this over 1000 iterations because benchmarking nanosecond operations is hard to get consistent, so that gives a good view of the larger performance gain.

Generally, on OS X and Windows, the change gives between 10-15% performance gain.

Signed-off-by: Mike Lloyd <mlloyd@pivotal.io>