### PR TITLE
Cache Distribution

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -70,11 +70,13 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 	itemIndex := shard.hashmap[hashedKey]
 
 	if itemIndex == 0 {
+		shard.lock.RUnlock()
 		return nil, notFound(key)
 	}
 
 	wrappedEntry, err := shard.entries.Get(int(itemIndex))
 	if err != nil {
+		shard.lock.RUnlock()
 		return nil, err
 	}
 	if entryKey := readKeyFromEntry(wrappedEntry); key != entryKey {
@@ -84,6 +86,7 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 		shard.lock.RUnlock()
 		return nil, notFound(key)
 	}
+	shard.lock.RUnlock()
 	return readEntry(wrappedEntry), nil
 }
 

--- a/bigcache.go
+++ b/bigcache.go
@@ -66,7 +66,6 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 	hashedKey := c.hash.Sum64(key)
 	shard := c.getShard(hashedKey)
 	shard.lock.RLock()
-	defer shard.lock.RUnlock()
 
 	itemIndex := shard.hashmap[hashedKey]
 

--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkWriteToCacheWith1Shard(b *testing.B) {
 
 func BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 	m := blob('a', 1024)
-	cache, _ := NewBigCache(Config{1, 100 * time.Second, 100, 256, false, nil, 1, nil})
+	cache, _ := NewBigCache(Config{1, 100 * time.Second, 100, 256, false, nil, 1, nil, false, nil})
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -26,7 +26,7 @@ func BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 
 func BenchmarkWriteToUnlimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 	m := blob('a', 1024)
-	cache, _ := NewBigCache(Config{1, 100 * time.Second, 100, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{1, 100 * time.Second, 100, 256, false, nil, 0, nil, false, nil})
 
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
@@ -56,7 +56,7 @@ func BenchmarkIterateOverCache(b *testing.B) {
 
 	for _, shards := range []int{512, 1024, 8192} {
 		b.Run(fmt.Sprintf("%d-shards", shards), func(b *testing.B) {
-			cache, _ := NewBigCache(Config{shards, 1000 * time.Second, max(b.N, 100), 500, false, nil, 0, nil})
+			cache, _ := NewBigCache(Config{shards, 1000 * time.Second, max(b.N, 100), 500, false, nil, 0, nil, false, nil})
 
 			for i := 0; i < b.N; i++ {
 				cache.Set(fmt.Sprintf("key-%d", i), m)
@@ -83,7 +83,7 @@ func BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize(b *testing.B) {
 }
 
 func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsInLifeWindow int) {
-	cache, _ := NewBigCache(Config{shards, lifeWindow, max(requestsInLifeWindow, 100), 500, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{shards, lifeWindow, max(requestsInLifeWindow, 100), 500, false, nil, 0, nil, false, nil})
 	rand.Seed(time.Now().Unix())
 
 	b.RunParallel(func(pb *testing.PB) {
@@ -99,7 +99,7 @@ func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsIn
 }
 
 func readFromCache(b *testing.B, shards int) {
-	cache, _ := NewBigCache(Config{shards, 1000 * time.Second, max(b.N, 100), 500, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{shards, 1000 * time.Second, max(b.N, 100), 500, false, nil, 0, nil, false, nil})
 	for i := 0; i < b.N; i++ {
 		cache.Set(strconv.Itoa(i), message)
 	}

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -2,6 +2,7 @@ package bigcache
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -28,7 +29,7 @@ func TestConstructCacheWithDefaultHasher(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, false, nil, 0, nil, false, nil})
 
 	assert.IsType(t, fnv64a{}, cache.hash)
 }
@@ -37,7 +38,7 @@ func TestWillReturnErrorOnInvalidNumberOfPartitions(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, error := NewBigCache(Config{18, 5 * time.Second, 10, 256, false, nil, 0, nil})
+	cache, error := NewBigCache(Config{18, 5 * time.Second, 10, 256, false, nil, 0, nil, false, nil})
 
 	assert.Nil(t, cache)
 	assert.Error(t, error, "Shards number must be power of two")
@@ -47,7 +48,7 @@ func TestEntryNotFound(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, false, nil, 0, nil, false, nil})
 
 	// when
 	_, err := cache.Get("nonExistingKey")
@@ -61,7 +62,7 @@ func TestTimingEviction(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{1, time.Second, 1, 256, false, nil, 0, nil}, &clock)
+	cache, _ := newBigCache(Config{1, time.Second, 1, 256, false, nil, 0, nil, false, nil}, &clock)
 
 	// when
 	cache.Set("key", []byte("value"))
@@ -78,7 +79,7 @@ func TestTimingEvictionShouldEvictOnlyFromUpdatedShard(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{4, time.Second, 1, 256, false, nil, 0, nil}, &clock)
+	cache, _ := newBigCache(Config{4, time.Second, 1, 256, false, nil, 0, nil, false, nil}, &clock)
 
 	// when
 	cache.Set("key", []byte("value"))
@@ -102,7 +103,7 @@ func TestOnRemoveCallback(t *testing.T) {
 		assert.Equal(t, "key", key)
 		assert.Equal(t, []byte("value"), entry)
 	}
-	cache, _ := newBigCache(Config{1, time.Second, 1, 256, false, nil, 0, onRemove}, &clock)
+	cache, _ := newBigCache(Config{1, time.Second, 1, 256, false, nil, 0, onRemove, false, nil}, &clock)
 
 	// when
 	cache.Set("key", []byte("value"))
@@ -117,7 +118,7 @@ func TestCacheLen(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{8, time.Second, 1, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{8, time.Second, 1, 256, false, nil, 0, nil, false, nil})
 	keys := 1337
 	// when
 
@@ -133,7 +134,7 @@ func TestCacheReset(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{8, time.Second, 1, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{8, time.Second, 1, 256, false, nil, 0, nil, false, nil})
 	keys := 1337
 
 	// when
@@ -163,7 +164,7 @@ func TestIterateOnResetCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{8, time.Second, 1, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{8, time.Second, 1, 256, false, nil, 0, nil, false, nil})
 	keys := 1337
 
 	// when
@@ -182,7 +183,7 @@ func TestGetOnResetCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{8, time.Second, 1, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{8, time.Second, 1, 256, false, nil, 0, nil, false, nil})
 	keys := 1337
 
 	// when
@@ -204,7 +205,7 @@ func TestEntryUpdate(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{1, 6 * time.Second, 1, 256, false, nil, 0, nil}, &clock)
+	cache, _ := newBigCache(Config{1, 6 * time.Second, 1, 256, false, nil, 0, nil, false, nil}, &clock)
 
 	// when
 	cache.Set("key", []byte("value"))
@@ -222,7 +223,7 @@ func TestOldestEntryDeletionWhenMaxCacheSizeIsReached(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1, nil})
+	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1, nil, false, nil})
 
 	// when
 	cache.Set("key1", blob('a', 1024*400))
@@ -243,7 +244,7 @@ func TestRetrievingEntryShouldCopy(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1, nil})
+	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1, nil, false, nil})
 	cache.Set("key1", blob('a', 1024*400))
 	value, key1Err := cache.Get("key1")
 
@@ -263,7 +264,7 @@ func TestEntryBiggerThanMaxShardSizeError(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1, nil})
+	cache, _ := NewBigCache(Config{1, 5 * time.Second, 1, 1, false, nil, 1, nil, false, nil})
 
 	// when
 	err := cache.Set("key1", blob('a', 1024*1025))
@@ -276,7 +277,7 @@ func TestHashCollision(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, true, hashStub(5), 0, nil})
+	cache, _ := NewBigCache(Config{16, 5 * time.Second, 10, 256, true, hashStub(5), 0, nil, false, nil})
 
 	// when
 	cache.Set("liquid", []byte("value"))
@@ -300,6 +301,33 @@ func TestHashCollision(t *testing.T) {
 	// then
 	assert.Error(t, err)
 	assert.Nil(t, cachedValue)
+}
+
+func TestBigCacheFlushOnEviction(t *testing.T) {
+	t.Parallel()
+
+	// test locally to disk.
+	tmpFile, err := os.Create("temp.gob")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// new timer so we can wait.
+	timer := time.NewTimer(3 * time.Second)
+
+	// given
+	cache, _ := NewBigCache(Config{16, 1 * time.Second, 10, 256, true, hashStub(5), 0, nil, true, tmpFile})
+
+	// when
+	if err = cache.Set("testGobWriter", []byte("testData")); err != nil {
+		t.Fatal(err)
+	}
+
+	// then
+	<-timer.C
+
+	// cleanup
+	tmpFile.Close()
 }
 
 type mockedClock struct {

--- a/config.go
+++ b/config.go
@@ -1,6 +1,9 @@
 package bigcache
 
-import "time"
+import (
+	"time"
+	"io"
+)
 
 // Config for BigCache
 type Config struct {
@@ -25,6 +28,10 @@ type Config struct {
 	// OnRemove is a callback fired when the oldest entry is removed because of its expiration time or no space left
 	// for the new entry. Default value is nil which means no callback and it prevents from unwrapping the oldest entry.
 	OnRemove func(key string, entry []byte)
+	// Store will determine if the cache should be written to the StoreWriter on cache eviction.
+	Store bool
+	// StoreWriter is the destination writer for bigcache.Flush(), so the cache can be sent to either a file or network destionation.
+	StoreWriter io.Writer
 }
 
 // DefaultConfig initializes config with default values.
@@ -38,6 +45,7 @@ func DefaultConfig(eviction time.Duration) Config {
 		Verbose:            true,
 		Hasher:             newDefaultHasher(),
 		HardMaxCacheSize:   0,
+		Store: false,
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ type Config struct {
 	// Verbose mode prints information about new memory allocation
 	Verbose bool
 	// Hasher used to map between string keys and unsigned 64bit integers, by default fnv64 hashing is used.
-	Hasher Hasher
+	Hasher Hasher `json:"-"`
 	// HardMaxCacheSize is a limit for cache size in MB. Cache will not allocate more memory than this limit.
 	// It can protect application from consuming all available memory on machine, therefore from running OOM Killer.
 	// Default value is 0 which means unlimited size. When the limit is higher than 0 and reached then
@@ -27,11 +27,11 @@ type Config struct {
 	HardMaxCacheSize int
 	// OnRemove is a callback fired when the oldest entry is removed because of its expiration time or no space left
 	// for the new entry. Default value is nil which means no callback and it prevents from unwrapping the oldest entry.
-	OnRemove func(key string, entry []byte)
+	OnRemove func(key string, entry []byte) `json:"-"`
 	// Store will determine if the cache should be written to the StoreWriter on cache eviction.
 	Store bool
 	// StoreWriter is the destination writer for bigcache.Flush(), so the cache can be sent to either a file or network destionation.
-	StoreWriter io.Writer
+	StoreWriter io.Writer `json:"-"`
 }
 
 // DefaultConfig initializes config with default values.

--- a/config.go
+++ b/config.go
@@ -1,8 +1,8 @@
 package bigcache
 
 import (
-	"time"
 	"io"
+	"time"
 )
 
 // Config for BigCache
@@ -45,7 +45,7 @@ func DefaultConfig(eviction time.Duration) Config {
 		Verbose:            true,
 		Hasher:             newDefaultHasher(),
 		HardMaxCacheSize:   0,
-		Store: false,
+		Store:              false,
 	}
 }
 

--- a/iterator.go
+++ b/iterator.go
@@ -58,10 +58,10 @@ type EntryInfoIterator struct {
 func copyCurrentShardMap(shard *cacheShard) ([]uint32, int) {
 	shard.lock.RLock()
 
-	var elements = make([]uint32, len(shard.hashmap))
+	var elements = make([]uint32, len(shard.Hashmap))
 	next := 0
 
-	for _, index := range shard.hashmap {
+	for _, index := range shard.Hashmap {
 		elements[next] = index
 		next++
 	}
@@ -83,8 +83,8 @@ func (it *EntryInfoIterator) SetNext() bool {
 		return true
 	}
 
-	for i := it.currentShard + 1; i < it.cache.config.Shards; i++ {
-		it.elements, it.elementsCount = copyCurrentShardMap(it.cache.shards[i])
+	for i := it.currentShard + 1; i < it.cache.Config.Shards; i++ {
+		it.elements, it.elementsCount = copyCurrentShardMap(it.cache.Shards[i])
 
 		// Non empty shard - stick with it
 		if it.elementsCount > 0 {
@@ -99,7 +99,7 @@ func (it *EntryInfoIterator) SetNext() bool {
 }
 
 func newIterator(cache *BigCache) *EntryInfoIterator {
-	elements, count := copyCurrentShardMap(cache.shards[0])
+	elements, count := copyCurrentShardMap(cache.Shards[0])
 
 	return &EntryInfoIterator{
 		cache:         cache,
@@ -119,7 +119,7 @@ func (it *EntryInfoIterator) Value() (EntryInfo, error) {
 		return emptyEntryInfo, ErrInvalidIteratorState
 	}
 
-	entry, err := it.cache.shards[it.currentShard].entries.Get(int(it.elements[it.currentIndex]))
+	entry, err := it.cache.Shards[it.currentShard].Entries.Get(int(it.elements[it.currentIndex]))
 
 	if err != nil {
 		return emptyEntryInfo, ErrCannotRetrieveEntry

--- a/iterator.go
+++ b/iterator.go
@@ -57,7 +57,6 @@ type EntryInfoIterator struct {
 
 func copyCurrentShardMap(shard *cacheShard) ([]uint32, int) {
 	shard.lock.RLock()
-	defer shard.lock.RUnlock()
 
 	var elements = make([]uint32, len(shard.hashmap))
 	next := 0
@@ -67,6 +66,7 @@ func copyCurrentShardMap(shard *cacheShard) ([]uint32, int) {
 		next++
 	}
 
+	shard.lock.RUnlock()
 	return elements, next
 }
 

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -80,9 +80,9 @@ func TestEntriesIteratorWithConcurrentUpdate(t *testing.T) {
 	}
 
 	// Quite ugly but works
-	for i := 0; i < cache.config.Shards; i++ {
-		if oldestEntry, err := cache.shards[i].entries.Peek(); err == nil {
-			if err = cache.onEvict(oldestEntry, 10, cache.shards[i].removeOldestEntry); err != nil {
+	for i := 0; i < cache.Config.Shards; i++ {
+		if oldestEntry, err := cache.Shards[i].Entries.Peek(); err == nil {
+			if err = cache.onEvict(oldestEntry, 10, cache.Shards[i].removeOldestEntry); err != nil {
 				t.Error(err)
 			}
 		}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -13,7 +13,7 @@ func TestEntriesIterator(t *testing.T) {
 
 	// given
 	keysCount := 1000
-	cache, _ := NewBigCache(Config{8, 6 * time.Second, 1, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{8, 6 * time.Second, 1, 256, false, nil, 0, nil, false, nil})
 	value := []byte("value")
 
 	for i := 0; i < keysCount; i++ {
@@ -41,7 +41,7 @@ func TestEntriesIteratorWithMostShardsEmpty(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{8, 6 * time.Second, 1, 256, false, nil, 0, nil}, &clock)
+	cache, _ := newBigCache(Config{8, 6 * time.Second, 1, 256, false, nil, 0, nil, false, nil}, &clock)
 
 	cache.Set("key", []byte("value"))
 
@@ -67,7 +67,7 @@ func TestEntriesIteratorWithConcurrentUpdate(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{1, time.Second, 1, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{1, time.Second, 1, 256, false, nil, 0, nil, false, nil})
 
 	cache.Set("key", []byte("value"))
 
@@ -82,7 +82,9 @@ func TestEntriesIteratorWithConcurrentUpdate(t *testing.T) {
 	// Quite ugly but works
 	for i := 0; i < cache.config.Shards; i++ {
 		if oldestEntry, err := cache.shards[i].entries.Peek(); err == nil {
-			cache.onEvict(oldestEntry, 10, cache.shards[i].removeOldestEntry)
+			if err = cache.onEvict(oldestEntry, 10, cache.shards[i].removeOldestEntry); err != nil {
+				t.Error(err)
+			}
 		}
 	}
 
@@ -98,7 +100,7 @@ func TestEntriesIteratorWithAllShardsEmpty(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{1, time.Second, 1, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{1, time.Second, 1, 256, false, nil, 0, nil, false, nil})
 
 	// when
 	iterator := cache.Iterator()
@@ -113,7 +115,7 @@ func TestEntriesIteratorInInvalidState(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{1, time.Second, 1, 256, false, nil, 0, nil})
+	cache, _ := NewBigCache(Config{1, time.Second, 1, 256, false, nil, 0, nil, false, nil})
 
 	// when
 	iterator := cache.Iterator()

--- a/shard.go
+++ b/shard.go
@@ -7,20 +7,20 @@ import (
 )
 
 type cacheShard struct {
-	hashmap     map[uint64]uint32
-	entries     queue.BytesQueue
+	Hashmap     map[uint64]uint32 `json:"hashmap"`
+	Entries     queue.BytesQueue  `json:"entries"`
 	lock        sync.RWMutex
-	entryBuffer []byte
+	EntryBuffer []byte `json:"entry_buffer"`
 	onRemove    func(wrappedEntry []byte)
 }
 
 type onRemoveCallback func(wrappedEntry []byte)
 
 func (s *cacheShard) removeOldestEntry() error {
-	oldest, err := s.entries.Pop()
+	oldest, err := s.Entries.Pop()
 	if err == nil {
 		hash := readHashFromEntry(oldest)
-		delete(s.hashmap, hash)
+		delete(s.Hashmap, hash)
 		s.onRemove(oldest)
 		return nil
 	}
@@ -30,22 +30,22 @@ func (s *cacheShard) removeOldestEntry() error {
 func (s *cacheShard) reset(config Config) {
 	s.lock.Lock()
 
-	s.hashmap = make(map[uint64]uint32, config.initialShardSize())
-	s.entryBuffer = make([]byte, config.MaxEntrySize+headersSizeInBytes)
-	s.entries.Reset()
+	s.Hashmap = make(map[uint64]uint32, config.initialShardSize())
+	s.EntryBuffer = make([]byte, config.MaxEntrySize+headersSizeInBytes)
+	s.Entries.Reset()
 
 	s.lock.Unlock()
 }
 
 func (s *cacheShard) len() int {
-	return len(s.hashmap)
+	return len(s.Hashmap)
 }
 
 func initNewShard(config Config, callback onRemoveCallback) *cacheShard {
 	return &cacheShard{
-		hashmap:     make(map[uint64]uint32, config.initialShardSize()),
-		entries:     *queue.NewBytesQueue(config.initialShardSize()*config.MaxEntrySize, config.maximumShardSize(), config.Verbose),
-		entryBuffer: make([]byte, config.MaxEntrySize+headersSizeInBytes),
+		Hashmap:     make(map[uint64]uint32, config.initialShardSize()),
+		Entries:     *queue.NewBytesQueue(config.initialShardSize()*config.MaxEntrySize, config.maximumShardSize(), config.Verbose),
+		EntryBuffer: make([]byte, config.MaxEntrySize+headersSizeInBytes),
 		onRemove:    callback,
 	}
 }

--- a/shard.go
+++ b/shard.go
@@ -29,11 +29,12 @@ func (s *cacheShard) removeOldestEntry() error {
 
 func (s *cacheShard) reset(config Config) {
 	s.lock.Lock()
-	defer s.lock.Unlock()
 
 	s.hashmap = make(map[uint64]uint32, config.initialShardSize())
 	s.entryBuffer = make([]byte, config.MaxEntrySize+headersSizeInBytes)
 	s.entries.Reset()
+
+	s.lock.Unlock()
 }
 
 func (s *cacheShard) len() int {


### PR DESCRIPTION
Adds io.Writer interface to flush cache on eviction and/or manually via new bigcache.Flush() API to an arbitrary destination.

Tests to match.