### PR TITLE
Use RLock/RUnlock for read shard.Len

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -145,9 +145,9 @@ func (c *BigCache) Len() int {
 	var len int
 
 	for _, shard := range c.shards {
-		shard.lock.Lock()
+		shard.lock.RLock()
 		len += shard.len()
-		shard.lock.Unlock()
+		shard.lock.RUnlock()
 	}
 
 	return len


### PR DESCRIPTION
I've not found any reasons why this should stay with Lock/Unlock.