### PR TITLE
Extract Lock/Unlock from shard

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -134,7 +134,9 @@ func (c *BigCache) Set(key string, entry []byte) error {
 // Reset empties all cache shards
 func (c *BigCache) Reset() error {
 	for _, shard := range c.shards {
+		shard.lock.Lock()
 		shard.reset(c.config)
+		shard.lock.Unlock()
 	}
 
 	return nil

--- a/shard.go
+++ b/shard.go
@@ -28,13 +28,9 @@ func (s *cacheShard) removeOldestEntry() error {
 }
 
 func (s *cacheShard) reset(config Config) {
-	s.lock.Lock()
-
 	s.hashmap = make(map[uint64]uint32, config.initialShardSize())
 	s.entryBuffer = make([]byte, config.MaxEntrySize+headersSizeInBytes)
 	s.entries.Reset()
-
-	s.lock.Unlock()
 }
 
 func (s *cacheShard) len() int {


### PR DESCRIPTION
Looking at all usages of a shard, locks are assessed outside, but `reset` method still uses lock inside.
There is no gain in terms of performance, just consistency of the code.