### PR TITLE
Adding logging interface & default logger

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -371,6 +371,7 @@ func TestEntryBiggerThanMaxShardSizeError(t *testing.T) {
 func TestHashCollision(t *testing.T) {
 	t.Parallel()
 
+	ml := &mockedLogger{}
 	// given
 	cache, _ := NewBigCache(Config{
 		Shards:             16,
@@ -379,6 +380,7 @@ func TestHashCollision(t *testing.T) {
 		MaxEntrySize:       256,
 		Verbose:            true,
 		Hasher:             hashStub(5),
+		Logger:             ml,
 	})
 
 	// when
@@ -403,6 +405,18 @@ func TestHashCollision(t *testing.T) {
 	// then
 	assert.Error(t, err)
 	assert.Nil(t, cachedValue)
+
+	assert.NotEqual(t, "", ml.lastFormat)
+}
+
+type mockedLogger struct {
+	lastFormat string
+	lastArgs   []interface{}
+}
+
+func (ml *mockedLogger) Printf(format string, v ...interface{}) {
+	ml.lastFormat = format
+	ml.lastArgs = v
 }
 
 type mockedClock struct {

--- a/config.go
+++ b/config.go
@@ -28,6 +28,10 @@ type Config struct {
 	// OnRemove is a callback fired when the oldest entry is removed because of its expiration time or no space left
 	// for the new entry. Default value is nil which means no callback and it prevents from unwrapping the oldest entry.
 	OnRemove func(key string, entry []byte)
+
+	// Logger is a logging interface and used in combination with `Verbose`
+	// Defaults to `DefaultLogger()`
+	Logger Logger
 }
 
 // DefaultConfig initializes config with default values.
@@ -42,6 +46,7 @@ func DefaultConfig(eviction time.Duration) Config {
 		Verbose:            true,
 		Hasher:             newDefaultHasher(),
 		HardMaxCacheSize:   0,
+		Logger:             DefaultLogger(),
 	}
 }
 

--- a/logger.go
+++ b/logger.go
@@ -10,6 +10,9 @@ type Logger interface {
 	Printf(format string, v ...interface{})
 }
 
+// this is a safeguard, breaking on compile time in case
+// `log.Logger` does not adhere to our `Logger` interface.
+// see https://golang.org/doc/faq#guarantee_satisfies_interface
 var _ Logger = &log.Logger{}
 
 // DefaultLogger returns a `Logger` implementation

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,27 @@
+package bigcache
+
+import (
+	"log"
+	"os"
+)
+
+// Logger is invoked when `Config.Verbose=true`
+type Logger interface {
+	Printf(format string, v ...interface{})
+}
+
+var _ Logger = &log.Logger{}
+
+// DefaultLogger returns a `Logger` implementation
+// backed by stdlib's log
+func DefaultLogger() *log.Logger {
+	return log.New(os.Stdout, "", log.LstdFlags)
+}
+
+func newLogger(custom Logger) Logger {
+	if custom != nil {
+		return custom
+	}
+
+	return DefaultLogger()
+}


### PR DESCRIPTION
👋 ohai !

This maintains backwards compatibility in terms of logging format, also keeps `Verbose` as main toggle.

IMO: it would look better to 🔪  `Verbose` , keep only `Logger` and have a default noop-logger. However, that means breaking api compatibility.

Fixes #36 