### PR TITLE
Added basic HTTP server implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .idea
 .DS_Store
+/server/server.exe
+/server/server

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,91 @@
+# BigCache HTTP Server
+
+This is a basic HTTP server implementation for BigCache. It has a basic RESTful API.
+
+```bash
+GET /api/v1/cache/{key}
+PUT /api/v1/cache/{key}
+```
+
+This server is designed to be consumed as a standalone executable, for things like Cloud Foundry, Heroku, etc.
+
+### Command-line Interface
+
+```powershell
+PS C:\go\src\github.com\mxplusb\bigcache\server> .\server.exe -h
+Usage of C:\go\src\github.com\mxplusb\bigcache\server\server.exe:
+  -lifetime int
+        Lifetime, in minutes, of each cache object. (default 10)
+  -logfile string
+        Location of the logfile.
+  -max int
+        Maximum amount of objects in the cache. (default 8192)
+  -maxInWindow int
+        Used only in initial memory allocation. (default 600000)
+  -maxShardEntrySize int
+        The maximum size of each object stored in a shard. Used only in initial memory allocation. (default 500)
+  -port int
+        The port to listen on. (default 9090)
+  -shards int
+        Number of shards for the cache. (default 1024)
+  -v    Verbose logging.
+
+```
+
+Example:
+
+```bash
+$ curl -v -XPUT localhost:9090/api/v1/cache/example -d "yay!"
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> PUT /api/v1/cache/example HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+> Content-Length: 4
+> Content-Type: application/x-www-form-urlencoded
+>
+* upload completely sent off: 4 out of 4 bytes
+< HTTP/1.1 201 Created
+< Date: Fri, 17 Nov 2017 03:50:07 GMT
+< Content-Length: 0
+< Content-Type: text/plain; charset=utf-8
+<
+* Connection #0 to host localhost left intact
+$ 
+$ curl -v -XGET localhost:9090/api/v1/cache/example
+Note: Unnecessary use of -X or --request, GET is already inferred.
+*   Trying 127.0.0.1...
+* Connected to localhost (127.0.0.1) port 9090 (#0)
+> GET /api/v1/cache/example HTTP/1.1
+> Host: localhost:9090
+> User-Agent: curl/7.47.0
+> Accept: */*
+>
+< HTTP/1.1 200 OK
+< Date: Fri, 17 Nov 2017 03:50:23 GMT
+< Content-Length: 4
+< Content-Type: text/plain; charset=utf-8
+<
+* Connection #0 to host localhost left intact
+yay!
+```
+
+The server does log basic metrics:
+
+```bash
+$ ./server
+2017/11/16 22:49:22 cache initialised.
+2017/11/16 22:49:22 starting server on :9090
+2017/11/16 22:50:07 stored "example" in cache.
+2017/11/16 22:50:07 request took 277000ns.
+2017/11/16 22:50:23 request took 9000ns.
+```
+
+### Acquiring
+
+This is native Go with no external dependencies, so it will compile for all supported Golang platforms. To build:
+
+```bash
+go build server.go
+```

--- a/server/server.go
+++ b/server/server.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/allegro/bigcache"
+)
+
+const (
+	// base HTTP paths.
+	apiVersion  = "v1"
+	apiBasePath = "/api/" + apiVersion + "/"
+
+	// path to cache.
+	cachePath = apiBasePath + "cache/"
+)
+
+var (
+	port    int
+	logfile string
+
+	// cache-specific settings.
+	cache  *bigcache.BigCache
+	config = bigcache.Config{}
+)
+
+func init() {
+	flag.BoolVar(&config.Verbose, "v", false, "Verbose logging.")
+	flag.IntVar(&config.Shards, "shards", 1024, "Number of shards for the cache.")
+	flag.IntVar(&config.MaxEntriesInWindow, "maxInWindow", 1000*10*60, "Used only in initial memory allocation.")
+	flag.DurationVar(&config.LifeWindow, "lifetime", 100000*100000*60, "Lifetime of each cache object.")
+	flag.IntVar(&config.HardMaxCacheSize, "max", 8192, "Maximum amount of data in the cache in MB.")
+	flag.IntVar(&config.MaxEntrySize, "maxShardEntrySize", 500, "The maximum size of each object stored in a shard. Used only in initial memory allocation.")
+	flag.IntVar(&port, "port", 9090, "The port to listen on.")
+	flag.StringVar(&logfile, "logfile", "", "Location of the logfile.")
+}
+
+func main() {
+	flag.Parse()
+
+	var logger *log.Logger
+
+	if logfile == "" {
+		logger = log.New(os.Stdout, "", log.LstdFlags)
+	} else {
+		f, err := os.OpenFile(logfile, os.O_APPEND|os.O_WRONLY, 0600)
+		if err != nil {
+			panic(err)
+		}
+		logger = log.New(f, "", log.LstdFlags)
+	}
+
+	var err error
+	cache, err = bigcache.NewBigCache(config)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	logger.Print("cache initialised.")
+
+	// let the middleware log.
+	http.Handle(cachePath, serviceLoader(cacheIndexHandler(), requestMetrics(logger)))
+
+	logger.Printf("starting server on :%d", port)
+
+	strPort := ":" + strconv.Itoa(port)
+	log.Fatal("ListenAndServe: ", http.ListenAndServe(strPort, nil))
+}
+
+// our base middleware implementation.
+type service func(http.Handler) http.Handler
+
+// chain load middleware services.
+func serviceLoader(h http.Handler, svcs ...service) http.Handler {
+	for _, svc := range svcs {
+		h = svc(h)
+	}
+	return h
+}
+
+func cacheIndexHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			getCacheHandler(w, r)
+		case http.MethodPut:
+			putCacheHandler(w, r)
+		}
+	})
+}
+
+// middleware for request length metrics.
+func requestMetrics(l *log.Logger) service {
+	return func(h http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			start := time.Now()
+			h.ServeHTTP(w, r)
+			l.Printf("request took %vns.", time.Now().Sub(start).Nanoseconds())
+		})
+	}
+}
+
+// handles get requests.
+func getCacheHandler(w http.ResponseWriter, r *http.Request) {
+	target := r.URL.Path[len(cachePath):]
+	if target == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("can't get a key if there is no key."))
+		log.Print("empty request.")
+		return
+	}
+	entry, err := cache.Get(target)
+	if err != nil {
+		errMsg := (err).Error()
+		if strings.Contains(errMsg, "not found") {
+			log.Print(err)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		log.Print(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.Write(entry)
+}
+
+func putCacheHandler(w http.ResponseWriter, r *http.Request) {
+	target := r.URL.Path[len(cachePath):]
+	if target == "" {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("can't put a key if there is no key."))
+		log.Print("empty request.")
+		return
+	}
+
+	entry, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		log.Print(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	if err := cache.Set(target, []byte(entry)); err != nil {
+		log.Print(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	log.Printf("stored \"%s\" in cache.", target)
+	w.WriteHeader(http.StatusCreated)
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/allegro/bigcache"
+)
+
+const (
+	testBaseString = "http://bigcache.org"
+)
+
+func testCacheSetup() {
+	cache, _ = bigcache.NewBigCache(bigcache.Config{
+		Shards:             1024,
+		LifeWindow:         10 * time.Minute,
+		MaxEntriesInWindow: 1000 * 10 * 60,
+		MaxEntrySize:       500,
+		Verbose:            true,
+		HardMaxCacheSize:   8192,
+		OnRemove:           nil,
+	})
+}
+
+func TestMain(m *testing.M) {
+	testCacheSetup()
+	m.Run()
+}
+
+func TestGetWithNoKey(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest("GET", testBaseString+"/api/v1/cache/", nil)
+	rr := httptest.NewRecorder()
+
+	getCacheHandler(rr, req)
+	resp := rr.Result()
+
+	if resp.StatusCode != 400 {
+		t.Errorf("want: 400; got: %d", resp.StatusCode)
+	}
+}
+
+func TestGetWithMissingKey(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest("GET", testBaseString+"/api/v1/cache/doesNotExist", nil)
+	rr := httptest.NewRecorder()
+
+	getCacheHandler(rr, req)
+	resp := rr.Result()
+
+	if resp.StatusCode != 404 {
+		t.Errorf("want: 404; got: %d", resp.StatusCode)
+	}
+}
+
+func TestGetKey(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest("GET", testBaseString+"/api/v1/cache/getKey", nil)
+	rr := httptest.NewRecorder()
+
+	// set something.
+	cache.Set("getKey", []byte("123"))
+
+	getCacheHandler(rr, req)
+	resp := rr.Result()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("cannot deserialise test response: %s", err)
+	}
+
+	if string(body) != "123" {
+		t.Errorf("want: 123; got: %s.\n\tcan't get existing key getKey.", string(body))
+	}
+}
+
+func TestPutKey(t *testing.T) {
+	t.Parallel()
+	req := httptest.NewRequest("PUT", testBaseString+"/api/v1/cache/putKey", bytes.NewBuffer([]byte("123")))
+	rr := httptest.NewRecorder()
+
+	putCacheHandler(rr, req)
+
+	testPutKeyResult, err := cache.Get("putKey")
+	if err != nil {
+		t.Errorf("error returning cache entry: %s", err)
+	}
+
+	if string(testPutKeyResult) != "123" {
+		t.Errorf("want: 123; got: %s.\n\tcan't get PUT key putKey.", string(testPutKeyResult))
+	}
+}
+
+func TestPutEmptyKey(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest("PUT", testBaseString+"/api/v1/cache/", bytes.NewBuffer([]byte("123")))
+	rr := httptest.NewRecorder()
+
+	putCacheHandler(rr, req)
+	resp := rr.Result()
+
+	if resp.StatusCode != 400 {
+		t.Errorf("want: 400; got: %d.\n\tempty key insertion should return with 400", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
Features:
Basic HTTP server.
Basic middleware implementation.

I wanted to provide some thoughts on this implementation.

API Surface:

```
GET /api/v1/cache/{key}
PUT /api/v1/cache/{key}
```

The API path denotes it's an API which is versioned, so making changes/implementing new features allows it to be versioned easily. I felt `PUT` was more relevant than `POST` because `bigcache.BigCache.Set()` will overwrite an existing key of the same name. `PUT` more closely aligns with the semantic aspect of the feature as opposed to the spirit. When looking at the `/cache/` heirarchy of the path, there was a PR I saw recently which looked to implement stats about the cache. If it gets approved, you can add `/api/v1/stats` to the API surface as an extra API. Overall, this API surface seemed easily sustainable to me.

HTTP Implementation:

What I love about this package is the focus is on performance and the standard library. My proposal suggested using the standard library, so I felt that was important. When looking at implementation options, I wanted something that could be easily extensible without pulling in dependencies. This [post](https://medium.com/@matryer/writing-middleware-in-golang-and-how-go-makes-it-so-much-fun-4375c1246e81) gave me a great idea, and I liked the adapter idea because it's highly extensible using only the standard library. If you want to implement request tracing, it's easy to do by adding a quick service adapter; if you want to implement some form of authentication or geo-limitation, just add another service adapter. The `requestMetrics()` feature, to me, is both a way to log basic metrics about the HTTP server, as well as an example for a basic service adapter.

Overall, my goal with this implementation was a focus on the standard library with no external dependencies in a highly extensible way.