### PR TITLE
Fix some race conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ script:
   - golint ./... # This won't break the build, just show warnings
   - ineffassign .
   - go vet ./...
-  - go test -race -coverprofile=web.coverprofile ./queue
-  - go test -race -coverprofile=main.coverprofile 
+  - go test -race -count=1 -coverprofile=queue.coverprofile ./queue
+  - go test -race -count=1 -coverprofile=server.coverprofile ./server
+  - go test -race -count=1 -coverprofile=main.coverprofile
   - $HOME/gopath/bin/gover
   - $HOME/gopath/bin/goveralls -coverprofile=gover.coverprofile -service travis-ci


### PR DESCRIPTION
1. Run every package on travis
2. No more race condition in `shard.GetStats`
3. No more race condition in `shard.del`
4. New `TestParallel` test to have `Set`, `Get`, `Del` operations running in parallel.