### PR TITLE
fixed gc bug and updated readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ Writes to map are the slowest.
 cd caches_bench; go run caches_gc_overhead_comparison.go
 
 Number of entries:  20000000
-GC pause for bigcache:  27.81671ms
-GC pause for freecache:  30.218371ms
-GC pause for map:  11.590772251s
+GC pause for bigcache:  5.8658ms
+GC pause for freecache:  32.4341ms
+GC pause for map:  52.9661ms
 ```
 
 Test shows how long are the GC pauses for caches filled with 20mln of entries.

--- a/caches_bench/caches_gc_overhead_comparison.go
+++ b/caches_bench/caches_gc_overhead_comparison.go
@@ -14,7 +14,7 @@ func gcPause() time.Duration {
 	runtime.GC()
 	var stats debug.GCStats
 	debug.ReadGCStats(&stats)
-	return stats.Pause[0]
+	return stats.PauseTotal
 }
 
 const (


### PR DESCRIPTION
Looking at #59, I wanted to do a quick once over of the comparisons in
1.10 so we can make sure our numbers are still accurate. When looking
through the GC code, I discovered we are using the wrong GC stat. Using
debug.GCStats.Pause[0] uses the most recent GC pause, which can be zero
(as I found out on Windows). We should be using total pause for all
collections, which is debug.GCStats.PauseTotal. That will show the total
length of time for all GC activities during our test, which more
accurately reflects the type of comparison we are trying to show.

Also, I updated the readme to reflect our GC comparison with go1.10.

fixes #59

Signed-off-by: Mike Lloyd <mike@reboot3times.org>