### PR TITLE
Add tests to prove/enforce 0-value byte slice caching

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -511,6 +511,43 @@ func TestHashCollision(t *testing.T) {
 	assert.Equal(t, cache.Stats().Collisions, int64(1))
 }
 
+func TestNilValueCaching(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{
+		Shards:             1,
+		LifeWindow:         5 * time.Second,
+		MaxEntriesInWindow: 1,
+		MaxEntrySize:       1,
+		HardMaxCacheSize:   1,
+	})
+
+	// when
+	cache.Set("Kierkegaard", []byte{})
+	cachedValue, err := cache.Get("Kierkegaard")
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{}, cachedValue)
+
+	// when
+	cache.Set("Sartre", nil)
+	cachedValue, err = cache.Get("Sartre")
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{}, cachedValue)
+
+	// when
+	cache.Set("Nietzsche", []byte(nil))
+	cachedValue, err = cache.Get("Nietzsche")
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{}, cachedValue)
+}
+
 type mockedLogger struct {
 	lastFormat string
 	lastArgs   []interface{}


### PR DESCRIPTION
My team is currently using this library for a new application- essentially just a cache that sits in front of one of our slower, on-disk data stores and holds a portion of the data for faster access.

One of our requirements is that we can cache failed reads from the database- ie, a read where the key is not found in the database. This is intended to reduce traffic to the database when a large portion of the keys are not found.

I implemented his by caching the key with a nil value- something bigcache implicitly supports already. I figured it would be a decent idea to make the support more explicit with some tests.