### PR TITLE
updated .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,9 @@
 .DS_Store
 /server/server.exe
 /server/server
+/server/server_dar*
+/server/server_fre*
+/server/server_win*
+/server/server_net*
+/server/server_ope*
 CHANGELOG.md


### PR DESCRIPTION
preventing gox build artifacts from being checked in.

gox is an easy tool to cross compile for all platforms. I will use it when building release binaries, so having those artifacts be ignored is nice. see: https://github.com/mitchellh/gox

Signed-off-by: Mike Lloyd <mike@reboot3times.org>