### PR TITLE
Allow for GC of cache when CleanWindow is set

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -2,6 +2,7 @@ package bigcache
 
 import (
 	"fmt"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -615,6 +616,25 @@ func TestNilValueCaching(t *testing.T) {
 	// then
 	assert.NoError(t, err)
 	assert.Equal(t, []byte{}, cachedValue)
+}
+
+func TestClosing(t *testing.T) {
+	// given
+	config := Config{
+		CleanWindow: time.Minute,
+	}
+	startGR := runtime.NumGoroutine()
+
+	// when
+	for i := 0; i < 100; i++ {
+		cache, _ := NewBigCache(config)
+		cache.Close()
+	}
+
+	// then
+	endGR := runtime.NumGoroutine()
+	assert.True(t, endGR >= startGR)
+	assert.InDelta(t, endGR, startGR, 25)
 }
 
 type mockedLogger struct {


### PR DESCRIPTION
This change makes `BigCache` an `io.Closer`. When closed, the cleaning goroutine is signaled to exit. This prevents the following:

- Stack leak due to goroutines not exiting.
- Heap leak do to the cleaning goroutine keeping a reference to the cache.
- Leak of the resources associated with maintaining the `time.Ticker`.

Fixes #82

As a test for this I wrote the following program:

```go
package main

import (
	"bytes"
	"log"
	"runtime"
	"time"

	"github.com/allegro/bigcache"
)

var data = bytes.Repeat([]byte("W"), 2^24)

func main() {
	go func() {
		var stats runtime.MemStats
		for {
			runtime.ReadMemStats(&stats)
			log.Printf("HeapAlloc: %d\n", stats.HeapAlloc)
			log.Printf("StackSys: %d\n", stats.StackSys)
			log.Printf("NumGoroutine: %d\n", runtime.NumGoroutine())
			time.Sleep(3 * time.Second)
		}
	}()

	for {
		doSomething()
	}
}

func doSomething() {
	config := bigcache.DefaultConfig(10 * time.Minute)
	config.CleanWindow = time.Minute
	cache, err := bigcache.NewBigCache(config)
	if err != nil {
		log.Fatal(err)
	}
	defer func() {
		err := cache.Close()
		if err != nil {
			log.Fatal(err)
		}
	}()
	err = cache.Set("data", data)
	if err != nil {
		log.Fatal(err)
	}
}
```

This prints out some runtime stats every three seconds and then proceeds to create, use, and destroy a `BigCache`. Without the fix these were the results:

```
2018/05/18 17:41:40 HeapAlloc: 445304
2018/05/18 17:41:40 StackSys: 262144
2018/05/18 17:41:40 NumGoroutine: 2
2018/05/18 17:41:43 HeapAlloc: 84984811896
2018/05/18 17:41:43 StackSys: 1310720
2018/05/18 17:41:43 NumGoroutine: 267
2018/05/18 17:41:46 HeapAlloc: 148253529632
2018/05/18 17:41:46 StackSys: 1703936
2018/05/18 17:41:46 NumGoroutine: 465
2018/05/18 17:41:49 HeapAlloc: 205597568264
2018/05/18 17:41:49 StackSys: 2097152
2018/05/18 17:41:49 NumGoroutine: 645
2018/05/18 17:41:52 HeapAlloc: 268698921088
2018/05/18 17:41:52 StackSys: 2523136
2018/05/18 17:41:52 NumGoroutine: 842
2018/05/18 17:41:55 HeapAlloc: 332629323408
2018/05/18 17:41:55 StackSys: 2916352
2018/05/18 17:41:55 NumGoroutine: 1042
2018/05/18 17:41:58 HeapAlloc: 377982809312
2018/05/18 17:41:58 StackSys: 3211264
2018/05/18 17:41:58 NumGoroutine: 1184
2018/05/18 17:42:01 HeapAlloc: 440917432696
2018/05/18 17:42:01 StackSys: 3604480
2018/05/18 17:42:01 NumGoroutine: 1380
2018/05/18 17:42:04 HeapAlloc: 505203506584
2018/05/18 17:42:04 StackSys: 4063232
2018/05/18 17:42:04 NumGoroutine: 1582
runtime: out of memory: cannot allocate 327680-byte block (549751455744 in use)
fatal error: out of memory

...
```

It ran for 24 seconds and then crashed from OOM. The stacks grew to 4 MB with 1582 goroutines and heap grew to 505 GB. I then ran the experiment with the fix:

```
2018/05/18 17:56:55 HeapAlloc: 429080
2018/05/18 17:56:55 StackSys: 262144
2018/05/18 17:56:55 NumGoroutine: 2
2018/05/18 17:56:58 HeapAlloc: 135035336
2018/05/18 17:56:58 StackSys: 655360
2018/05/18 17:56:58 NumGoroutine: 2
2018/05/18 17:57:01 HeapAlloc: 343322000
2018/05/18 17:57:01 StackSys: 786432
2018/05/18 17:57:01 NumGoroutine: 2
...
2018/05/18 17:58:49 HeapAlloc: 198509072
2018/05/18 17:58:49 StackSys: 1179648
2018/05/18 17:58:49 NumGoroutine: 2
2018/05/18 17:58:52 HeapAlloc: 255337424
2018/05/18 17:58:52 StackSys: 1179648
2018/05/18 17:58:52 NumGoroutine: 2
2018/05/18 17:58:55 HeapAlloc: 416465072
2018/05/18 17:58:55 StackSys: 1179648
2018/05/18 17:58:55 NumGoroutine: 2
signal: interrupt
```

It ran for over a minute before I got bored and killed it. The stacks leveled off at 1 MB with 2 goroutines and heap stayed around 100-500 MB.

In my experience, growth in stacks due to goroutine leaks are usually something you see in programs running in production for weeks to months. Memory use keeps growing over time and heap dumps show no sign of where the memory is being used. This can be better demonstrated with a smaller payload so the program doesn't crash but I don't think that demonstration is needed here.