### PR TITLE
improved EntryNotFoundError

### DIFF
--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -98,6 +98,14 @@ func BenchmarkWriteToCacheWith1024ShardsAndSmallShardInitSize(b *testing.B) {
 	writeToCache(b, 1024, 100*time.Second, 100)
 }
 
+func BenchmarkReadFromCacheNonExistentKeys(b *testing.B) {
+	for _, shards := range []int{1, 512, 1024, 8192} {
+		b.Run(fmt.Sprintf("%d-shards", shards), func(b *testing.B) {
+			readFromCacheNonExistentKeys(b, 1024)
+		})
+	}
+}
+
 func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsInLifeWindow int) {
 	cache, _ := NewBigCache(Config{
 		Shards:             shards,
@@ -129,6 +137,24 @@ func readFromCache(b *testing.B, shards int) {
 	for i := 0; i < b.N; i++ {
 		cache.Set(strconv.Itoa(i), message)
 	}
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		b.ReportAllocs()
+
+		for pb.Next() {
+			cache.Get(strconv.Itoa(rand.Intn(b.N)))
+		}
+	})
+}
+
+func readFromCacheNonExistentKeys(b *testing.B, shards int) {
+	cache, _ := NewBigCache(Config{
+		Shards:             shards,
+		LifeWindow:         1000 * time.Second,
+		MaxEntriesInWindow: max(b.N, 100),
+		MaxEntrySize:       500,
+	})
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {

--- a/entry_not_found_error.go
+++ b/entry_not_found_error.go
@@ -4,14 +4,14 @@ import "fmt"
 
 // EntryNotFoundError is an error type struct which is returned when entry was not found for provided key
 type EntryNotFoundError struct {
-	message string
+	key string
 }
 
 func notFound(key string) error {
-	return &EntryNotFoundError{fmt.Sprintf("Entry %q not found", key)}
+	return &EntryNotFoundError{key}
 }
 
 // Error returned when entry does not exist.
 func (e EntryNotFoundError) Error() string {
-	return e.message
+	return fmt.Sprintf("Entry %q not found", e.key)
 }


### PR DESCRIPTION
- [x] error message will be generated on demand
- [x] added bench readFromCacheNonExistentKeys

before:
```
BenchmarkReadFromCacheNonExistentKeys/1-shards-4         	 5000000	       275 ns/op	      71 B/op	       3 allocs/op
BenchmarkReadFromCacheNonExistentKeys/512-shards-4       	 5000000	       291 ns/op	      71 B/op	       3 allocs/op
BenchmarkReadFromCacheNonExistentKeys/1024-shards-4      	 5000000	       269 ns/op	      71 B/op	       3 allocs/op
BenchmarkReadFromCacheNonExistentKeys/8192-shards-4      	 5000000	       277 ns/op	      71 B/op	       3 allocs/op
```


after:
```
BenchmarkReadFromCacheNonExistentKeys/1-shards-4         	10000000	       197 ns/op	      23 B/op	       1 allocs/op
BenchmarkReadFromCacheNonExistentKeys/512-shards-4       	10000000	       187 ns/op	      23 B/op	       1 allocs/op
BenchmarkReadFromCacheNonExistentKeys/1024-shards-4      	10000000	       159 ns/op	      23 B/op	       1 allocs/op
BenchmarkReadFromCacheNonExistentKeys/8192-shards-4      	10000000	       177 ns/op	      23 B/op	       1 allocs/op
```