### PR TITLE
Avoid data copying in Set()

### DIFF
--- a/encoding.go
+++ b/encoding.go
@@ -29,6 +29,26 @@ func wrapEntry(timestamp uint64, hash uint64, key string, entry []byte, buffer *
 	return blob[:blobLength]
 }
 
+func wrapEntryExact(timestamp uint64, hash uint64, key string, entry []byte, blob []byte) {
+	keyLength := len(key)
+	blobLength := len(entry) + headersSizeInBytes + keyLength
+
+	if blobLength != len(blob) {
+		panic("wrapped entry size not match")
+	}
+	binary.LittleEndian.PutUint64(blob, timestamp)
+	binary.LittleEndian.PutUint64(blob[timestampSizeInBytes:], hash)
+	binary.LittleEndian.PutUint16(blob[timestampSizeInBytes+hashSizeInBytes:], uint16(keyLength))
+	copy(blob[headersSizeInBytes:], key)
+	copy(blob[headersSizeInBytes+keyLength:], entry)
+}
+
+func wrapEntrySize(key string, entry []byte) int {
+	keyLength := len(key)
+	blobLength := len(entry) + headersSizeInBytes + keyLength
+	return blobLength
+}
+
 func readEntry(data []byte) []byte {
 	length := binary.LittleEndian.Uint16(data[timestampSizeInBytes+hashSizeInBytes:])
 

--- a/encoding_test.go
+++ b/encoding_test.go
@@ -44,3 +44,21 @@ func TestAllocateBiggerBuffer(t *testing.T) {
 	assert.Equal(t, data, readEntry(wrapped))
 	assert.Equal(t, 2+headersSizeInBytes, len(buffer))
 }
+
+func TestExactEncodeDecode(t *testing.T) {
+	// given
+	now := uint64(time.Now().Unix())
+	hash := uint64(42)
+	key := "key"
+	data := []byte("data")
+	buffer := make([]byte, wrapEntrySize(key, data))
+
+	// when
+	wrapEntryExact(now, hash, key, data, buffer)
+
+	// then
+	assert.Equal(t, key, readKeyFromEntry(buffer))
+	assert.Equal(t, hash, readHashFromEntry(buffer))
+	assert.Equal(t, now, readTimestampFromEntry(buffer))
+	assert.Equal(t, data, readEntry(buffer))
+}

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -26,6 +26,28 @@ func TestPushAndPop(t *testing.T) {
 	assert.Equal(t, entry, pop(queue))
 }
 
+func TestPushAndPopDirty(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(10, 0, true)
+	entry := []byte("hello")
+
+	// when
+	_, err := queue.Pop()
+
+	// then
+	assert.EqualError(t, err, "Empty queue")
+
+	// when
+	_, buf, _ := queue.PushDirty(len(entry))
+	assert.Equal(t, len(entry), len(buf))
+	copy(buf, entry)
+
+	// then
+	assert.Equal(t, entry, pop(queue))
+}
+
 func TestLen(t *testing.T) {
 	t.Parallel()
 

--- a/shard.go
+++ b/shard.go
@@ -69,10 +69,10 @@ func (s *cacheShard) set(key string, hashedKey uint64, entry []byte) error {
 		s.onEvict(oldestEntry, currentTimestamp, s.removeOldestEntry)
 	}
 
-	w := wrapEntry(currentTimestamp, hashedKey, key, entry, &s.entryBuffer)
-
+	blobLen := wrapEntrySize(key, entry)
 	for {
-		if index, err := s.entries.Push(w); err == nil {
+		if index, buff, err := s.entries.PushDirty(blobLen); err == nil {
+			wrapEntryExact(currentTimestamp, hashedKey, key, entry, buff)
 			s.hashmap[hashedKey] = uint32(index)
 			s.lock.Unlock()
 			return nil


### PR DESCRIPTION
In current implemention, Set() first encode entry to local buffer, and 
then push data into queue. In this PR, Set() encodes entry directly into 
queue.

| name | old time/op | new time/op | delta |
| --- | --- | --- | --- |
| BigCacheSet-4 | 983ns ± 8% | 925ns ± 5% |-5.92% (p=0.040 n=5+5) |
| BigCacheSetParallel-4 | 521ns ± 4% | 496ns ± 4% |-4.80% (p=0.032 n=5+5) |
