### PR TITLE
Fix data race on iteration

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -144,9 +144,8 @@ func (s *cacheShard) getEntry(index int) ([]byte, error) {
 }
 
 func (s *cacheShard) copyKeys() (keys []uint32, next int) {
-	keys = make([]uint32, len(s.hashmap))
-
 	s.lock.RLock()
+	keys = make([]uint32, len(s.hashmap))
 
 	for _, index := range s.hashmap {
 		keys[next] = index

--- a/shard.go
+++ b/shard.go
@@ -140,7 +140,11 @@ func (s *cacheShard) getOldestEntry() ([]byte, error) {
 }
 
 func (s *cacheShard) getEntry(index int) ([]byte, error) {
-	return s.entries.Get(index)
+	s.lock.RLock()
+	entry, err := s.entries.Get(index)
+	s.lock.RUnlock()
+
+	return entry, err
 }
 
 func (s *cacheShard) copyKeys() (keys []uint32, next int) {


### PR DESCRIPTION
https://github.com/allegro/bigcache/issues/107

Panic happens, when some other guy is adding new values in parallel(out of range error) because of datarace
```
WARNING: DATA RACE
Read at 0x00c006115e00 by goroutine 6:
  github.com/allegro/bigcache.(*cacheShard).copyKeys()
      /Users/un0/go/src/github.com/allegro/bigcache/shard.go:147 +0x74
  github.com/allegro/bigcache.(*EntryInfoIterator).SetNext()
      /Users/un0/go/src/github.com/allegro/bigcache/iterator.go:72 +0x1f8
  github.com/un000/test/bigcache_test.TestBigCacheIter()
      /Users/un0/go/src/github.com/un000/test/bigcache/cache_test.go:32 +0x2e3
  testing.tRunner()
      /usr/local/Cellar/go/1.11/libexec/src/testing/testing.go:827 +0x162

Previous write at 0x00c006115e00 by goroutine 11:
  runtime.mapassign_fast64()
      /usr/local/Cellar/go/1.11/libexec/src/runtime/map_fast64.go:92 +0x0
  github.com/allegro/bigcache.(*cacheShard).set()
      /Users/un0/go/src/github.com/allegro/bigcache/shard.go:76 +0x302
  github.com/allegro/bigcache.(*BigCache).Set()
      /Users/un0/go/src/github.com/allegro/bigcache/bigcache.go:117 +0x156
  github.com/un000/test/bigcache_test.TestBigCacheIter.func1()
      /Users/un0/go/src/github.com/un000/test/bigcache/cache_test.go:21 +0xcc
```