### PR TITLE
replace EntryNotFoundError on ErrEntryNotFound

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -102,7 +102,7 @@ func (c *BigCache) Close() error {
 }
 
 // Get reads entry for the key.
-// It returns an EntryNotFoundError when
+// It returns an ErrEntryNotFound when
 // no entry exists for the given key.
 func (c *BigCache) Get(key string) ([]byte, error) {
 	hashedKey := c.hash.Sum64(key)

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -106,7 +106,7 @@ func TestEntryNotFound(t *testing.T) {
 	_, err := cache.Get("nonExistingKey")
 
 	// then
-	assert.EqualError(t, err, "Entry not found")
+	assert.EqualError(t, err, ErrEntryNotFound.Error())
 }
 
 func TestTimingEviction(t *testing.T) {
@@ -128,7 +128,7 @@ func TestTimingEviction(t *testing.T) {
 	_, err := cache.Get("key")
 
 	// then
-	assert.EqualError(t, err, "Entry not found")
+	assert.EqualError(t, err, ErrEntryNotFound.Error())
 }
 
 func TestTimingEvictionShouldEvictOnlyFromUpdatedShard(t *testing.T) {
@@ -150,7 +150,7 @@ func TestTimingEvictionShouldEvictOnlyFromUpdatedShard(t *testing.T) {
 	value, err := cache.Get("key")
 
 	// then
-	assert.NoError(t, err, "Entry not found")
+	assert.NoError(t, err, ErrEntryNotFound.Error())
 	assert.Equal(t, []byte("value"), value)
 }
 
@@ -172,7 +172,7 @@ func TestCleanShouldEvictAll(t *testing.T) {
 	value, err := cache.Get("key")
 
 	// then
-	assert.EqualError(t, err, "Entry not found")
+	assert.EqualError(t, err, ErrEntryNotFound.Error())
 	assert.Equal(t, value, []byte(nil))
 }
 
@@ -346,7 +346,7 @@ func TestCacheDel(t *testing.T) {
 	err := cache.Delete("nonExistingKey")
 
 	// then
-	assert.Equal(t, err.Error(), "Entry not found")
+	assert.Equal(t, err.Error(), ErrEntryNotFound.Error())
 
 	// and when
 	cache.Set("existingKey", nil)
@@ -439,7 +439,7 @@ func TestGetOnResetCache(t *testing.T) {
 	// then
 	value, err := cache.Get("key1")
 
-	assert.Equal(t, err.Error(), "Entry not found")
+	assert.Equal(t, err.Error(), ErrEntryNotFound.Error())
 	assert.Equal(t, value, []byte(nil))
 }
 
@@ -489,8 +489,8 @@ func TestOldestEntryDeletionWhenMaxCacheSizeIsReached(t *testing.T) {
 	entry3, _ := cache.Get("key3")
 
 	// then
-	assert.EqualError(t, key1Err, "Entry not found")
-	assert.EqualError(t, key2Err, "Entry not found")
+	assert.EqualError(t, key1Err, ErrEntryNotFound.Error())
+	assert.EqualError(t, key2Err, ErrEntryNotFound.Error())
 	assert.Equal(t, blob('c', 1024*800), entry3)
 }
 

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -106,7 +106,7 @@ func TestEntryNotFound(t *testing.T) {
 	_, err := cache.Get("nonExistingKey")
 
 	// then
-	assert.EqualError(t, err, "Entry \"nonExistingKey\" not found")
+	assert.EqualError(t, err, "Entry not found")
 }
 
 func TestTimingEviction(t *testing.T) {
@@ -128,7 +128,7 @@ func TestTimingEviction(t *testing.T) {
 	_, err := cache.Get("key")
 
 	// then
-	assert.EqualError(t, err, "Entry \"key\" not found")
+	assert.EqualError(t, err, "Entry not found")
 }
 
 func TestTimingEvictionShouldEvictOnlyFromUpdatedShard(t *testing.T) {
@@ -150,7 +150,7 @@ func TestTimingEvictionShouldEvictOnlyFromUpdatedShard(t *testing.T) {
 	value, err := cache.Get("key")
 
 	// then
-	assert.NoError(t, err, "Entry \"key\" not found")
+	assert.NoError(t, err, "Entry not found")
 	assert.Equal(t, []byte("value"), value)
 }
 
@@ -172,7 +172,7 @@ func TestCleanShouldEvictAll(t *testing.T) {
 	value, err := cache.Get("key")
 
 	// then
-	assert.EqualError(t, err, "Entry \"key\" not found")
+	assert.EqualError(t, err, "Entry not found")
 	assert.Equal(t, value, []byte(nil))
 }
 
@@ -346,7 +346,7 @@ func TestCacheDel(t *testing.T) {
 	err := cache.Delete("nonExistingKey")
 
 	// then
-	assert.Equal(t, err.Error(), "Entry \"nonExistingKey\" not found")
+	assert.Equal(t, err.Error(), "Entry not found")
 
 	// and when
 	cache.Set("existingKey", nil)
@@ -439,7 +439,7 @@ func TestGetOnResetCache(t *testing.T) {
 	// then
 	value, err := cache.Get("key1")
 
-	assert.Equal(t, err.Error(), "Entry \"key1\" not found")
+	assert.Equal(t, err.Error(), "Entry not found")
 	assert.Equal(t, value, []byte(nil))
 }
 
@@ -489,8 +489,8 @@ func TestOldestEntryDeletionWhenMaxCacheSizeIsReached(t *testing.T) {
 	entry3, _ := cache.Get("key3")
 
 	// then
-	assert.EqualError(t, key1Err, "Entry \"key1\" not found")
-	assert.EqualError(t, key2Err, "Entry \"key2\" not found")
+	assert.EqualError(t, key1Err, "Entry not found")
+	assert.EqualError(t, key2Err, "Entry not found")
 	assert.Equal(t, blob('c', 1024*800), entry3)
 }
 

--- a/entry_not_found_error.go
+++ b/entry_not_found_error.go
@@ -1,17 +1,6 @@
 package bigcache
 
-import "fmt"
+import "errors"
 
-// EntryNotFoundError is an error type struct which is returned when entry was not found for provided key
-type EntryNotFoundError struct {
-	key string
-}
-
-func notFound(key string) error {
-	return &EntryNotFoundError{key}
-}
-
-// Error returned when entry does not exist.
-func (e EntryNotFoundError) Error() string {
-	return fmt.Sprintf("Entry %q not found", e.key)
-}
+// ErrEntryNotFound is an error type struct which is returned when entry was not found for provided key
+var ErrEntryNotFound = errors.New("Entry not found")

--- a/shard.go
+++ b/shard.go
@@ -32,7 +32,7 @@ func (s *cacheShard) get(key string, hashedKey uint64) ([]byte, error) {
 	if itemIndex == 0 {
 		s.lock.RUnlock()
 		s.miss()
-		return nil, notFound(key)
+		return nil, ErrEntryNotFound
 	}
 
 	wrappedEntry, err := s.entries.Get(int(itemIndex))
@@ -47,7 +47,7 @@ func (s *cacheShard) get(key string, hashedKey uint64) ([]byte, error) {
 		}
 		s.lock.RUnlock()
 		s.collision()
-		return nil, notFound(key)
+		return nil, ErrEntryNotFound
 	}
 	s.lock.RUnlock()
 	s.hit()
@@ -91,7 +91,7 @@ func (s *cacheShard) del(key string, hashedKey uint64) error {
 	if itemIndex == 0 {
 		s.lock.RUnlock()
 		s.delmiss()
-		return notFound(key)
+		return ErrEntryNotFound
 	}
 
 	wrappedEntry, err := s.entries.Get(int(itemIndex))


### PR DESCRIPTION
I reconsidered my approach to `EntryNotFoundError` error. User always knows what key he uses, so we can delete `EntryNotFoundError` structure and replace it to `ErrEntryNotFound`


```
benchmark                                                old ns/op     new ns/op     delta
BenchmarkReadFromCacheNonExistentKeys/1-shards-12        185           181           -2.16%
BenchmarkReadFromCacheNonExistentKeys/512-shards-12      182           179           -1.65%
BenchmarkReadFromCacheNonExistentKeys/1024-shards-12     184           180           -2.17%
BenchmarkReadFromCacheNonExistentKeys/8192-shards-12     182           176           -3.30%

benchmark                                                old allocs     new allocs     delta
BenchmarkReadFromCacheNonExistentKeys/1-shards-12        1              0              -100.00%
BenchmarkReadFromCacheNonExistentKeys/512-shards-12      1              0              -100.00%
BenchmarkReadFromCacheNonExistentKeys/1024-shards-12     1              0              -100.00%
BenchmarkReadFromCacheNonExistentKeys/8192-shards-12     1              0              -100.00%

benchmark                                                old bytes     new bytes     delta
BenchmarkReadFromCacheNonExistentKeys/1-shards-12        24            8             -66.67%
BenchmarkReadFromCacheNonExistentKeys/512-shards-12      23            7             -69.57%
BenchmarkReadFromCacheNonExistentKeys/1024-shards-12     24            8             -66.67%
BenchmarkReadFromCacheNonExistentKeys/8192-shards-12     23            7             -69.57%
```