### PR TITLE
fix server_test to clear TestCacheIndexHandler

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -223,26 +223,27 @@ func TestGetStatsIndex(t *testing.T) {
 }
 
 func TestCacheIndexHandler(t *testing.T) {
-	getreq := httptest.NewRequest("PUT", testBaseString+"/api/v1/cache/getKey", nil)
-	putreq := httptest.NewRequest("PUT", testBaseString+"/api/v1/cache/putKey", bytes.NewBuffer([]byte("123")))
-	delreq := httptest.NewRequest("DELETE", testBaseString+"/api/v1/cache/testDeleteKey", bytes.NewBuffer([]byte("123")))
+	getreq := httptest.NewRequest("GET", testBaseString+"/api/v1/cache/testkey", nil)
+	putreq := httptest.NewRequest("PUT", testBaseString+"/api/v1/cache/testkey", bytes.NewBuffer([]byte("123")))
+	delreq := httptest.NewRequest("DELETE", testBaseString+"/api/v1/cache/testkey", bytes.NewBuffer([]byte("123")))
 
-	rr := httptest.NewRecorder()
+	getrr := httptest.NewRecorder()
+	putrr := httptest.NewRecorder()
+	delrr := httptest.NewRecorder()
 	testHandlers := cacheIndexHandler()
 
-	testHandlers.ServeHTTP(rr, putreq)
-	resp := rr.Result()
-	if resp.StatusCode != 200 {
-		t.Errorf("want: 200; got: %d.\n\tcan't delete keys.", resp.StatusCode)
+	testHandlers.ServeHTTP(putrr, putreq)
+	resp := putrr.Result()
+	if resp.StatusCode != 201 {
+		t.Errorf("want: 201; got: %d.\n\tcan't put keys.", resp.StatusCode)
 	}
-	testHandlers.ServeHTTP(rr, getreq)
-	resp = rr.Result()
+	testHandlers.ServeHTTP(getrr, getreq)
+	resp = getrr.Result()
 	if resp.StatusCode != 200 {
-		t.Errorf("want: 200; got: %d.\n\tcan't delete keys.", resp.StatusCode)
+		t.Errorf("want: 200; got: %d.\n\tcan't get keys.", resp.StatusCode)
 	}
-
-	testHandlers.ServeHTTP(rr, delreq)
-	resp = rr.Result()
+	testHandlers.ServeHTTP(delrr, delreq)
+	resp = delrr.Result()
 	if resp.StatusCode != 200 {
 		t.Errorf("want: 200; got: %d.\n\tcan't delete keys.", resp.StatusCode)
 	}


### PR DESCRIPTION
sorry I added TestCacheIndexHandler to failed following now
on HEAD result:
```
$ cd server
$ go test -v ./...
=== RUN   TestServiceLoader
--- PASS: TestServiceLoader (0.00s)
=== RUN   TestRequestMetrics
2019/01/13 23:06:21 Entry not found
--- PASS: TestRequestMetrics (0.00s)
    middleware_test.go:46: 2019/01/13 23:06:21 GET request to /api/v1/cache/empty took 180951ns.

=== RUN   TestGetWithNoKey
=== PAUSE TestGetWithNoKey
=== RUN   TestGetWithMissingKey
=== PAUSE TestGetWithMissingKey
=== RUN   TestGetKey
=== PAUSE TestGetKey
=== RUN   TestPutKey
=== PAUSE TestPutKey
=== RUN   TestPutEmptyKey
=== PAUSE TestPutEmptyKey
=== RUN   TestDeleteEmptyKey
=== PAUSE TestDeleteEmptyKey
=== RUN   TestDeleteInvalidKey
=== PAUSE TestDeleteInvalidKey
=== RUN   TestDeleteKey
=== PAUSE TestDeleteKey
=== RUN   TestGetStats
=== PAUSE TestGetStats
=== RUN   TestGetStatsIndex
=== PAUSE TestGetStatsIndex
=== RUN   TestCacheIndexHandler
2019/01/13 23:06:21 stored "putKey" in cache.
2019/01/13 23:06:21 stored "getKey" in cache.
2019/01/13 23:06:21 testDeleteKey not found.
--- FAIL: TestCacheIndexHandler (0.00s)
    server_test.go:236: want: 200; got: 201.
                can't delete keys.
    server_test.go:241: want: 200; got: 201.
                can't delete keys.
    server_test.go:247: want: 200; got: 201.
                can't delete keys.
=== CONT  TestGetWithNoKey
2019/01/13 23:06:21 empty request.
=== CONT  TestDeleteInvalidKey
--- PASS: TestGetWithNoKey (0.00s)
2019/01/13 23:06:21 invalidDeleteKey not found.
=== CONT  TestGetKey
=== CONT  TestGetWithMissingKey
=== CONT  TestDeleteEmptyKey
2019/01/13 23:06:21 Entry not found
--- PASS: TestGetWithMissingKey (0.00s)
=== CONT  TestGetStats
=== CONT  TestPutEmptyKey
2019/01/13 23:06:21  not found.
--- PASS: TestDeleteEmptyKey (0.00s)
=== CONT  TestDeleteKey
--- PASS: TestDeleteInvalidKey (0.00s)
=== CONT  TestGetStatsIndex
--- PASS: TestDeleteKey (0.00s)
=== CONT  TestPutKey
2019/01/13 23:06:21 stored "putKey" in cache.
--- PASS: TestPutKey (0.00s)
2019/01/13 23:06:21 empty request.
--- PASS: TestGetKey (0.00s)
--- PASS: TestPutEmptyKey (0.00s)
--- PASS: TestGetStats (0.00s)
--- PASS: TestGetStatsIndex (0.00s)
FAIL
ok      github.com/allegro/bigcache/server      0.034s
```
so, I fixed and retest to indicate passing all tests
```
$ cd server
$ go test -v ./...                                                                                                     
=== RUN   TestServiceLoader
--- PASS: TestServiceLoader (0.00s)
=== RUN   TestRequestMetrics
2019/01/13 23:04:42 Entry not found
--- PASS: TestRequestMetrics (0.00s)
    middleware_test.go:46: 2019/01/13 23:04:42 GET request to /api/v1/cache/empty took 221961ns.

=== RUN   TestGetWithNoKey
=== PAUSE TestGetWithNoKey
=== RUN   TestGetWithMissingKey
=== PAUSE TestGetWithMissingKey
=== RUN   TestGetKey
=== PAUSE TestGetKey
=== RUN   TestPutKey
=== PAUSE TestPutKey
=== RUN   TestPutEmptyKey
=== PAUSE TestPutEmptyKey
=== RUN   TestDeleteEmptyKey
=== PAUSE TestDeleteEmptyKey
=== RUN   TestDeleteInvalidKey
=== PAUSE TestDeleteInvalidKey
=== RUN   TestDeleteKey
=== PAUSE TestDeleteKey
=== RUN   TestGetStats
=== PAUSE TestGetStats
=== RUN   TestGetStatsIndex
=== PAUSE TestGetStatsIndex
=== RUN   TestCacheIndexHandler
2019/01/13 23:04:42 stored "testkey" in cache.
--- PASS: TestCacheIndexHandler (0.00s)
=== CONT  TestGetWithNoKey
2019/01/13 23:04:42 empty request.
--- PASS: TestGetWithNoKey (0.00s)
=== CONT  TestDeleteEmptyKey
2019/01/13 23:04:42  not found.
=== CONT  TestDeleteInvalidKey
--- PASS: TestDeleteEmptyKey (0.00s)
2019/01/13 23:04:42 invalidDeleteKey not found.
=== CONT  TestPutEmptyKey
--- PASS: TestDeleteInvalidKey (0.00s)
=== CONT  TestGetWithMissingKey
2019/01/13 23:04:42 empty request.
2019/01/13 23:04:42 Entry not found
--- PASS: TestGetWithMissingKey (0.00s)
=== CONT  TestGetStatsIndex
--- PASS: TestPutEmptyKey (0.00s)
=== CONT  TestGetKey
--- PASS: TestGetKey (0.00s)
=== CONT  TestGetStats
=== CONT  TestPutKey
2019/01/13 23:04:42 stored "putKey" in cache.
--- PASS: TestPutKey (0.00s)
=== CONT  TestDeleteKey
--- PASS: TestDeleteKey (0.00s)
--- PASS: TestGetStatsIndex (0.00s)
--- PASS: TestGetStats (0.00s)
PASS
ok      github.com/allegro/bigcache/server      0.033s
```