### PR TITLE
Fix data corruption (shard.go)

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -377,7 +377,7 @@ func TestCacheDelRandomly(t *testing.T) {
 	//c.Hasher = hashStub(5)
 	cache, _ := NewBigCache(c)
 	var wg sync.WaitGroup
-	var ntest = 200000
+	var ntest = 800000
 	wg.Add(1)
 	go func() {
 		for i := 0; i < ntest; i++ {

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -362,7 +362,7 @@ func TestCacheDel(t *testing.T) {
 
 // TestCacheDelRandomly does simultaneous deletes, puts and gets, to check for corruption errors.
 func TestCacheDelRandomly(t *testing.T) {
-
+	t.Parallel()
 	c := Config{
 		Shards:             1,
 		LifeWindow:         time.Second,

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -377,8 +377,8 @@ func TestCacheDelRandomly(t *testing.T) {
 	//c.Hasher = hashStub(5)
 	cache, _ := NewBigCache(c)
 	var wg sync.WaitGroup
-	wg.Add(3)
-	var ntest = 100000
+	var ntest = 200000
+	wg.Add(1)
 	go func() {
 		for i := 0; i < ntest; i++ {
 			r := uint8(rand.Int())
@@ -388,6 +388,7 @@ func TestCacheDelRandomly(t *testing.T) {
 		}
 		wg.Done()
 	}()
+	wg.Add(1)
 	go func() {
 		val := make([]byte, 1024)
 		for i := 0; i < ntest; i++ {
@@ -401,6 +402,7 @@ func TestCacheDelRandomly(t *testing.T) {
 		}
 		wg.Done()
 	}()
+	wg.Add(1)
 	go func() {
 		val := make([]byte, 1024)
 		for i := 0; i < ntest; i++ {

--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -162,6 +162,11 @@ func (q *BytesQueue) Get(index int) ([]byte, error) {
 	return data, err
 }
 
+// CheckGet checks if an entry can be read from index
+func (q *BytesQueue) CheckGet(index int) error {
+	return q.peekCheckErr(index)
+}
+
 // Capacity returns number of allocated bytes for queue
 func (q *BytesQueue) Capacity() int {
 	return q.capacity
@@ -175,6 +180,23 @@ func (q *BytesQueue) Len() int {
 // Error returns error message
 func (e *queueError) Error() string {
 	return e.message
+}
+
+// peekCheckErr is identical to peek, but does not actually return any data
+func (q *BytesQueue) peekCheckErr(index int) error {
+
+	if q.count == 0 {
+		return &queueError{"Empty queue"}
+	}
+
+	if index <= 0 {
+		return &queueError{"Index must be grater than zero. Invalid index."}
+	}
+
+	if index+headerEntrySize >= len(q.array) {
+		return &queueError{"Index out of range"}
+	}
+	return nil
 }
 
 func (q *BytesQueue) peek(index int) ([]byte, int, error) {

--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -16,6 +16,12 @@ const (
 	minimumEmptyBlobSize = 32 + headerEntrySize
 )
 
+var (
+	errEmptyQueue       = &queueError{"Empty queue"}
+	errInvalidIndex     = &queueError{"Index must be greater than zero. Invalid index."}
+	errIndexOutOfBounds = &queueError{"Index out of range"}
+)
+
 // BytesQueue is a non-thread safe queue type of fifo based on bytes array.
 // For every push operation index of entry is returned. It can be used to read the entry later
 type BytesQueue struct {
@@ -186,15 +192,15 @@ func (e *queueError) Error() string {
 func (q *BytesQueue) peekCheckErr(index int) error {
 
 	if q.count == 0 {
-		return &queueError{"Empty queue"}
+		return errEmptyQueue
 	}
 
 	if index <= 0 {
-		return &queueError{"Index must be grater than zero. Invalid index."}
+		return errInvalidIndex
 	}
 
 	if index+headerEntrySize >= len(q.array) {
-		return &queueError{"Index out of range"}
+		return errIndexOutOfBounds
 	}
 	return nil
 }
@@ -202,15 +208,15 @@ func (q *BytesQueue) peekCheckErr(index int) error {
 func (q *BytesQueue) peek(index int) ([]byte, int, error) {
 
 	if q.count == 0 {
-		return nil, 0, &queueError{"Empty queue"}
+		return nil, 0, errEmptyQueue
 	}
 
 	if index <= 0 {
-		return nil, 0, &queueError{"Index must be grater than zero. Invalid index."}
+		return nil, 0, errInvalidIndex
 	}
 
 	if index+headerEntrySize >= len(q.array) {
-		return nil, 0, &queueError{"Index out of range"}
+		return nil, 0, errIndexOutOfBounds
 	}
 
 	blockSize := int(binary.LittleEndian.Uint32(q.array[index : index+headerEntrySize]))

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -50,16 +50,19 @@ func TestPeek(t *testing.T) {
 
 	// when
 	read, err := queue.Peek()
-
+	err2 := queue.peekCheckErr(queue.head)
 	// then
+	assert.Equal(t, err, err2)
 	assert.EqualError(t, err, "Empty queue")
 	assert.Nil(t, read)
 
 	// when
 	queue.Push(entry)
 	read, err = queue.Peek()
+	err2 = queue.peekCheckErr(queue.head)
 
 	// then
+	assert.Equal(t, err, err2)
 	assert.NoError(t, err)
 	assert.Equal(t, pop(queue), read)
 	assert.Equal(t, entry, read)
@@ -286,10 +289,12 @@ func TestGetEntryFromInvalidIndex(t *testing.T) {
 
 	// when
 	result, err := queue.Get(0)
+	err2 := queue.CheckGet(0)
 
 	// then
+	assert.Equal(t, err, err2)
 	assert.Nil(t, result)
-	assert.EqualError(t, err, "Index must be grater than zero. Invalid index.")
+	assert.EqualError(t, err, "Index must be greater than zero. Invalid index.")
 }
 
 func TestGetEntryFromIndexOutOfRange(t *testing.T) {
@@ -301,8 +306,10 @@ func TestGetEntryFromIndexOutOfRange(t *testing.T) {
 
 	// when
 	result, err := queue.Get(42)
+	err2 := queue.CheckGet(42)
 
 	// then
+	assert.Equal(t, err, err2)
 	assert.Nil(t, result)
 	assert.EqualError(t, err, "Index out of range")
 }
@@ -315,8 +322,10 @@ func TestGetEntryFromEmptyQueue(t *testing.T) {
 
 	// when
 	result, err := queue.Get(1)
+	err2 := queue.CheckGet(1)
 
 	// then
+	assert.Equal(t, err, err2)
 	assert.Nil(t, result)
 	assert.EqualError(t, err, "Empty queue")
 }

--- a/shard.go
+++ b/shard.go
@@ -49,9 +49,10 @@ func (s *cacheShard) get(key string, hashedKey uint64) ([]byte, error) {
 		s.collision()
 		return nil, ErrEntryNotFound
 	}
+	entry := readEntry(wrappedEntry)
 	s.lock.RUnlock()
 	s.hit()
-	return readEntry(wrappedEntry), nil
+	return entry, nil
 }
 
 func (s *cacheShard) set(key string, hashedKey uint64, entry []byte) error {
@@ -136,6 +137,8 @@ func (s *cacheShard) cleanUp(currentTimestamp uint64) {
 }
 
 func (s *cacheShard) getOldestEntry() ([]byte, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
 	return s.entries.Peek()
 }
 


### PR DESCRIPTION
This PR contains a testcase which demonstrates corruption (intermittently). Sometimes leading to `panic`, and sometimes leading to data corruption of values. 

I thought that fixing the datarace suggested in #117 would solve it, but it seems I was wrong about that, there's some other underlying bug. I'll push a commit on top if I find it. 