### PR TITLE
DefaultConfig:change CleanWindow to 1 second

### DIFF
--- a/config.go
+++ b/config.go
@@ -48,7 +48,7 @@ func DefaultConfig(eviction time.Duration) Config {
 	return Config{
 		Shards:             1024,
 		LifeWindow:         eviction,
-		CleanWindow:        0,
+		CleanWindow:        1 * time.Second,
 		MaxEntriesInWindow: 1000 * 10 * 60,
 		MaxEntrySize:       500,
 		Verbose:            true,


### PR DESCRIPTION
Fixes an issue with the default config where no clean up is performed on cache if `CleanWindow: 0` is specified in the config.

Mentioned by @mxplusb at https://github.com/allegro/bigcache/issues/139#issuecomment-502762420