### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,6 @@ GC pause for map:  52.9661ms
 
 Test shows how long are the GC pauses for caches filled with 20mln of entries.
 Bigcache and freecache have very similar GC pause time.
-It is clear that both reduce GC overhead in contrast to map
-which GC pause time took more than 10 seconds.
 
 ### Memory usage
 


### PR DESCRIPTION
Looking at #59, I wanted to do a quick once over of the comparisons in
1.10 so we can make sure our numbers are still accurate. When looking
through the GC code, I discovered we are using the wrong GC stat. Using
debug.GCStats.Pause[0] uses the most recent GC pause, which can be zero
(as I found out on Windows). We should be using total pause for all
collections, which is debug.GCStats.PauseTotal. That will show the total
length of time for all GC activities during our test, which more
accurately reflects the type of comparison we are trying to show.

Also, I updated the readme to reflect our GC comparison with go1.10.

fixes #59 #163 

Signed-off-by: Mike Lloyd <mike@reboot3times.org>