### PR TITLE
Build on Github Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: Go Build
+on: [push]
+env:
+  GO111MODULE: on
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      max-parallel: 2
+      matrix:
+        go: ["1.12.x", "1.13.x"]
+
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{matrix.go}}
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+
+      - name: Lint code
+        run: |
+          gofiles=$(find ./ -name '*.go') && [ -z "$gofiles" ] || unformatted=$(goimports -l $gofiles) && [ -z "$unformatted" ] || (echo >&2 "Go files must be formatted with gofmt. Following files has problem: $unformatted" &&  true);
+          diff <(echo -n) <(gofmt -s -d .)
+          export PATH=$PATH:$(go env GOPATH)/bin # temporary fix. See https://github.com/actions/setup-go/issues/14
+          go get -u golang.org/x/lint/golint 
+          golint ./...
+
+      - name: Static code check
+        run: |
+          export PATH=$PATH:$(go env GOPATH)/bin
+          go get -u github.com/gordonklaus/ineffassign
+          ineffassign .
+          go vet ./...
+
+      - name: Test
+        run: |
+          go test -race -count=1 -coverprofile=queue.coverprofile ./queue
+          go test -race -count=1 -coverprofile=server.coverprofile  ./server
+          go test -race -count=1 -coverprofile=main.coverprofile
+
+      - name: Build
+        run: go build -v .


### PR DESCRIPTION
In the `lint code` step, I made an adjustment to allow failed `goimports` command to not exit the step. I noticed that running it in travis also results in that behaviour even though it's set to fail. We could have in the future a makefile and a comment back on the commit to know what adjustments need to be done.
