### PR TITLE
fix: concurrent write access

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -287,9 +287,9 @@ func (s *cacheShard) getKeyMetadata(key uint64) Metadata {
 func (s *cacheShard) hit(key uint64) {
 	atomic.AddInt64(&s.stats.Hits, 1)
 	if s.statsEnabled {
-		s.lock.RLock()
+		s.lock.Lock()
 		s.hashmapStats[key]++
-		s.lock.RUnlock()
+		s.lock.Unlock()
 	}
 }
 


### PR DESCRIPTION
While using bigcache today I encountered this error:  

```
fatal error: concurrent map writes
goroutine 2487 [running]:
runtime.throw(0xe697aa, 0x15)
	/usr/local/go/src/runtime/panic.go:774 +0x72 fp=0xc5878dd388 sp=0xc5878dd358 pc=0x4310c2
runtime.mapassign_fast64(0xd1eec0, 0xc347b05bf0, 0x44b94351220b245d, 0xc5880a8000)
	/usr/local/go/src/runtime/map_fast64.go:176 +0x337 fp=0xc5878dd3c8 sp=0xc5878dd388 pc=0x413897
github.com/allegro/bigcache/v2.(*cacheShard).hit(0xc349c61560, 0x44b94351220b245d)
```
This bug was introduced by me 2 month ago instead of using `Lock` I used `Rlock`