### PR TITLE
Move getOldestEntry to test file

### DIFF
--- a/iterator_test.go
+++ b/iterator_test.go
@@ -95,9 +95,15 @@ func TestEntriesIteratorWithConcurrentUpdate(t *testing.T) {
 		t.Errorf("Iterator should contain at least single element")
 	}
 
+	getOldestEntry := func(s *cacheShard) ([]byte, error) {
+		s.lock.RLock()
+		defer s.lock.RUnlock()
+		return s.entries.Peek()
+	}
+
 	// Quite ugly but works
 	for i := 0; i < cache.config.Shards; i++ {
-		if oldestEntry, err := cache.shards[i].getOldestEntry(); err == nil {
+		if oldestEntry, err := getOldestEntry(cache.shards[i]); err == nil {
 			cache.onEvict(oldestEntry, 10, cache.shards[i].removeOldestEntry)
 		}
 	}

--- a/shard.go
+++ b/shard.go
@@ -204,12 +204,6 @@ func (s *cacheShard) cleanUp(currentTimestamp uint64) {
 	s.lock.Unlock()
 }
 
-func (s *cacheShard) getOldestEntry() ([]byte, error) {
-	s.lock.RLock()
-	defer s.lock.RUnlock()
-	return s.entries.Peek()
-}
-
 func (s *cacheShard) getEntry(index int) ([]byte, error) {
 	s.lock.RLock()
 	entry, err := s.entries.Get(index)


### PR DESCRIPTION
Move `getOldestEntry` from production code to test where it's used.