### PR TITLE
fix read benchmarks

### DIFF
--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -56,7 +56,7 @@ func BenchmarkWriteToCache(b *testing.B) {
 func BenchmarkReadFromCache(b *testing.B) {
 	for _, shards := range []int{1, 512, 1024, 8192} {
 		b.Run(fmt.Sprintf("%d-shards", shards), func(b *testing.B) {
-			readFromCache(b, 1024, false)
+			readFromCache(b, shards, false)
 		})
 	}
 }
@@ -64,7 +64,7 @@ func BenchmarkReadFromCache(b *testing.B) {
 func BenchmarkReadFromCacheWithInfo(b *testing.B) {
 	for _, shards := range []int{1, 512, 1024, 8192} {
 		b.Run(fmt.Sprintf("%d-shards", shards), func(b *testing.B) {
-			readFromCache(b, 1024, true)
+			readFromCache(b, shards, true)
 		})
 	}
 }


### PR DESCRIPTION
Number of shards in `read` benchmarks is always set to 1024 instead of parametrized value.

This was broken since Go 1.7 https://github.com/allegro/bigcache/commit/90098c54320d4fcf6d9f0fd8ffeed76cfb9f96c3#r36883572