### PR TITLE
Use bytes.Repeat instead of for loop

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -853,9 +853,5 @@ func (mc *mockedClock) set(value int64) {
 }
 
 func blob(char byte, len int) []byte {
-	b := make([]byte, len)
-	for index := range b {
-		b[index] = char
-	}
-	return b
+	return bytes.Repeat([]byte{char}, len)
 }

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -369,11 +369,7 @@ func get(queue *BytesQueue, index int) []byte {
 }
 
 func blob(char byte, len int) []byte {
-	b := make([]byte, len)
-	for index := range b {
-		b[index] = char
-	}
-	return b
+	return bytes.Repeat([]byte{char}, len)
 }
 
 func assertEqual(t *testing.T, expected, actual interface{}, msgAndArgs ...interface{}) {


### PR DESCRIPTION
It looks like we reimplemented [`bytes.Repeat`](https://golang.org/pkg/bytes/#Repeat) functionality with `blob` function. Lets use as much code from stdlib as possible.