### PR TITLE
Optimize bytes_queue

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -426,7 +426,7 @@ func TestCacheCapacity(t *testing.T) {
 
 	// then
 	assertEqual(t, keys, cache.Len())
-	assertEqual(t, 81920, cache.Capacity())
+	//assertEqual(t, 81920, cache.Capacity())
 }
 
 func TestCacheStats(t *testing.T) {

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -426,7 +426,7 @@ func TestCacheCapacity(t *testing.T) {
 
 	// then
 	assertEqual(t, keys, cache.Len())
-	//assertEqual(t, 81920, cache.Capacity())
+	assertEqual(t, 40960, cache.Capacity())
 }
 
 func TestCacheStats(t *testing.T) {

--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -42,12 +42,17 @@ type queueError struct {
 }
 
 func getUVarintSize(x uint64) int {
-	i := 0
-	for x >= 0x80 {
-		x >>= 7
-		i++
+	if x < 128 {
+		return 1
+	} else if x < 16384 {
+		return 2
+	} else if x < 2097152 {
+		return 3
+	} else if x < 268435456 {
+		return 4
+	} else {
+		return 5
 	}
-	return i + 1
 }
 
 // NewBytesQueue initialize new bytes queue.

--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -226,9 +226,6 @@ func (q *BytesQueue) peek(index int) ([]byte, int, int, error) {
 	}
 
 	blockSize, n := binary.Uvarint(q.array[index:])
-	if n <= 0 {
-		panic("wrong encoding")
-	}
 	return q.array[index+n : index+n+int(blockSize)], int(blockSize), n, nil
 }
 

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -120,7 +120,7 @@ func TestReuseAvailableSpace(t *testing.T) {
 	queue.Push(blob('c', 20))
 
 	// then
-	assertEqual(t, 100, queue.Capacity())
+	//assertEqual(t, 100, queue.Capacity())
 	assertEqual(t, blob('b', 20), pop(queue))
 }
 
@@ -135,7 +135,7 @@ func TestAllocateAdditionalSpace(t *testing.T) {
 	queue.Push([]byte("hello2"))
 
 	// then
-	assertEqual(t, 22, queue.Capacity())
+	//assertEqual(t, 22, queue.Capacity())
 }
 
 func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereHeadIsBeforeTail(t *testing.T) {
@@ -151,7 +151,7 @@ func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereHeadIsBef
 	queue.Push(blob('c', 6)) // 10 bytes needed, 14 available but not in one segment, allocate additional memory
 
 	// then
-	assertEqual(t, 50, queue.Capacity())
+	//assertEqual(t, 50, queue.Capacity())
 	assertEqual(t, blob('b', 6), pop(queue))
 	assertEqual(t, blob('c', 6), pop(queue))
 }
@@ -169,7 +169,7 @@ func TestUnchangedEntriesIndexesAfterAdditionalMemoryAllocationWhereHeadIsBefore
 	newestIndex, _ := queue.Push(blob('c', 6)) // 10 bytes needed, 14 available but not in one segment, allocate additional memory
 
 	// then
-	assertEqual(t, 50, queue.Capacity())
+	//assertEqual(t, 50, queue.Capacity())
 	assertEqual(t, blob('b', 6), get(queue, index))
 	assertEqual(t, blob('c', 6), get(queue, newestIndex))
 }
@@ -188,12 +188,13 @@ func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereTailIsBef
 	queue.Push(blob('d', 40)) // 44 bytes needed but no available in one segment, allocate new memory
 
 	// then
-	assertEqual(t, 200, queue.Capacity())
+	//assertEqual(t, 200, queue.Capacity())
 	assertEqual(t, blob('c', 30), pop(queue))
 	// empty blob fills space between tail and head,
 	// created when additional memory was allocated,
 	// it keeps current entries indexes unchanged
-	assertEqual(t, blob(0, 36), pop(queue))
+	//assertEqual(t, blob(0, 36), pop(queue))
+	queue.Pop()
 	assertEqual(t, blob('b', 10), pop(queue))
 	assertEqual(t, blob('d', 40), pop(queue))
 }
@@ -212,7 +213,7 @@ func TestUnchangedEntriesIndexesAfterAdditionalMemoryAllocationWhereTailIsBefore
 	newestIndex, _ := queue.Push(blob('d', 40)) // 44 bytes needed but no available in one segment, allocate new memory
 
 	// then
-	assertEqual(t, 200, queue.Capacity())
+	//assertEqual(t, 200, queue.Capacity())
 	assertEqual(t, blob('b', 10), get(queue, index))
 	assertEqual(t, blob('d', 40), get(queue, newestIndex))
 }
@@ -228,7 +229,7 @@ func TestAllocateAdditionalSpaceForValueBiggerThanInitQueue(t *testing.T) {
 
 	// then
 	assertEqual(t, blob('a', 100), pop(queue))
-	assertEqual(t, 230, queue.Capacity())
+	//assertEqual(t, 230, queue.Capacity())
 }
 
 func TestAllocateAdditionalSpaceForValueBiggerThanQueue(t *testing.T) {
@@ -246,7 +247,7 @@ func TestAllocateAdditionalSpaceForValueBiggerThanQueue(t *testing.T) {
 	queue.Pop()
 	queue.Pop()
 	assertEqual(t, make([]byte, 100), pop(queue))
-	assertEqual(t, 250, queue.Capacity())
+	//assertEqual(t, 250, queue.Capacity())
 }
 
 func TestPopWholeQueue(t *testing.T) {
@@ -263,7 +264,7 @@ func TestPopWholeQueue(t *testing.T) {
 	queue.Push([]byte("c"))
 
 	// then
-	assertEqual(t, 13, queue.Capacity())
+	//assertEqual(t, 13, queue.Capacity())
 	assertEqual(t, []byte("c"), pop(queue))
 }
 
@@ -342,12 +343,11 @@ func TestMaxSizeLimit(t *testing.T) {
 	// when
 	queue.Push(blob('a', 25))
 	queue.Push(blob('b', 5))
-	capacity := queue.Capacity()
-	_, err := queue.Push(blob('c', 15))
-
+	//capacity := queue.Capacity()
+	//_, err := queue.Push(blob('c', 15))
 	// then
-	assertEqual(t, 50, capacity)
-	assertEqual(t, "Full queue. Maximum size limit reached.", err.Error())
+	//assertEqual(t, 50, capacity)
+	//assertEqual(t, "Full queue. Maximum size limit reached.", err.Error())
 	assertEqual(t, blob('a', 25), pop(queue))
 	assertEqual(t, blob('b', 5), pop(queue))
 }

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -120,7 +120,7 @@ func TestReuseAvailableSpace(t *testing.T) {
 	queue.Push(blob('c', 20))
 
 	// then
-	//assertEqual(t, 100, queue.Capacity())
+	assertEqual(t, 100, queue.Capacity())
 	assertEqual(t, blob('b', 20), pop(queue))
 }
 
@@ -135,7 +135,7 @@ func TestAllocateAdditionalSpace(t *testing.T) {
 	queue.Push([]byte("hello2"))
 
 	// then
-	//assertEqual(t, 22, queue.Capacity())
+	assertEqual(t, 22, queue.Capacity())
 }
 
 func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereHeadIsBeforeTail(t *testing.T) {
@@ -145,13 +145,13 @@ func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereHeadIsBef
 	queue := NewBytesQueue(25, 0, false)
 
 	// when
-	queue.Push(blob('a', 3)) // header + entry + left margin = 8 bytes
-	queue.Push(blob('b', 6)) // additional 10 bytes
-	queue.Pop()              // space freed, 7 bytes available at the beginning
-	queue.Push(blob('c', 6)) // 10 bytes needed, 14 available but not in one segment, allocate additional memory
+	queue.Push(blob('a', 3)) // header + entry + left margin = 5 bytes
+	queue.Push(blob('b', 6)) // additional 7 bytes
+	queue.Pop()              // space freed, 4 bytes available at the beginning
+	queue.Push(blob('c', 6)) // 7 bytes needed, 13 bytes available at the tail
 
 	// then
-	//assertEqual(t, 50, queue.Capacity())
+	assertEqual(t, 25, queue.Capacity())
 	assertEqual(t, blob('b', 6), pop(queue))
 	assertEqual(t, blob('c', 6), pop(queue))
 }
@@ -163,13 +163,13 @@ func TestUnchangedEntriesIndexesAfterAdditionalMemoryAllocationWhereHeadIsBefore
 	queue := NewBytesQueue(25, 0, false)
 
 	// when
-	queue.Push(blob('a', 3))                   // header + entry + left margin = 8 bytes
-	index, _ := queue.Push(blob('b', 6))       // additional 10 bytes
-	queue.Pop()                                // space freed, 7 bytes available at the beginning
-	newestIndex, _ := queue.Push(blob('c', 6)) // 10 bytes needed, 14 available but not in one segment, allocate additional memory
+	queue.Push(blob('a', 3))                   // header + entry + left margin = 5 bytes
+	index, _ := queue.Push(blob('b', 6))       // additional 7 bytes
+	queue.Pop()                                // space freed, 4 bytes available at the beginning
+	newestIndex, _ := queue.Push(blob('c', 6)) // 7 bytes needed, 13 available at the tail
 
 	// then
-	//assertEqual(t, 50, queue.Capacity())
+	assertEqual(t, 25, queue.Capacity())
 	assertEqual(t, blob('b', 6), get(queue, index))
 	assertEqual(t, blob('c', 6), get(queue, newestIndex))
 }
@@ -181,20 +181,19 @@ func TestAllocateAdditionalSpaceForInsufficientFreeFragmentedSpaceWhereTailIsBef
 	queue := NewBytesQueue(100, 0, false)
 
 	// when
-	queue.Push(blob('a', 70)) // header + entry + left margin = 75 bytes
-	queue.Push(blob('b', 10)) // 75 + 10 + 4 = 89 bytes
+	queue.Push(blob('a', 70)) // header + entry + left margin = 72 bytes
+	queue.Push(blob('b', 10)) // 72 + 10 + 1 = 83 bytes
 	queue.Pop()               // space freed at the beginning
-	queue.Push(blob('c', 30)) // 34 bytes used at the beginning, tail pointer is before head pointer
-	queue.Push(blob('d', 40)) // 44 bytes needed but no available in one segment, allocate new memory
+	queue.Push(blob('c', 30)) // 31 bytes used at the beginning, tail pointer is before head pointer
+	queue.Push(blob('d', 40)) // 41 bytes needed but no available in one segment, allocate new memory
 
 	// then
-	//assertEqual(t, 200, queue.Capacity())
+	assertEqual(t, 200, queue.Capacity())
 	assertEqual(t, blob('c', 30), pop(queue))
 	// empty blob fills space between tail and head,
 	// created when additional memory was allocated,
 	// it keeps current entries indexes unchanged
-	//assertEqual(t, blob(0, 36), pop(queue))
-	queue.Pop()
+	assertEqual(t, blob(0, 39), pop(queue))
 	assertEqual(t, blob('b', 10), pop(queue))
 	assertEqual(t, blob('d', 40), pop(queue))
 }
@@ -206,14 +205,14 @@ func TestUnchangedEntriesIndexesAfterAdditionalMemoryAllocationWhereTailIsBefore
 	queue := NewBytesQueue(100, 0, false)
 
 	// when
-	queue.Push(blob('a', 70))                   // header + entry + left margin = 75 bytes
-	index, _ := queue.Push(blob('b', 10))       // 75 + 10 + 4 = 89 bytes
+	queue.Push(blob('a', 70))                   // header + entry + left margin = 72 bytes
+	index, _ := queue.Push(blob('b', 10))       // 72 + 10 + 1 = 83 bytes
 	queue.Pop()                                 // space freed at the beginning
-	queue.Push(blob('c', 30))                   // 34 bytes used at the beginning, tail pointer is before head pointer
-	newestIndex, _ := queue.Push(blob('d', 40)) // 44 bytes needed but no available in one segment, allocate new memory
+	queue.Push(blob('c', 30))                   // 31 bytes used at the beginning, tail pointer is before head pointer
+	newestIndex, _ := queue.Push(blob('d', 40)) // 41 bytes needed but no available in one segment, allocate new memory
 
 	// then
-	//assertEqual(t, 200, queue.Capacity())
+	assertEqual(t, 200, queue.Capacity())
 	assertEqual(t, blob('b', 10), get(queue, index))
 	assertEqual(t, blob('d', 40), get(queue, newestIndex))
 }
@@ -226,10 +225,10 @@ func TestAllocateAdditionalSpaceForValueBiggerThanInitQueue(t *testing.T) {
 
 	// when
 	queue.Push(blob('a', 100))
-
 	// then
 	assertEqual(t, blob('a', 100), pop(queue))
-	//assertEqual(t, 230, queue.Capacity())
+	// 224 = (101 + 11) * 2
+	assertEqual(t, 224, queue.Capacity())
 }
 
 func TestAllocateAdditionalSpaceForValueBiggerThanQueue(t *testing.T) {
@@ -247,7 +246,8 @@ func TestAllocateAdditionalSpaceForValueBiggerThanQueue(t *testing.T) {
 	queue.Pop()
 	queue.Pop()
 	assertEqual(t, make([]byte, 100), pop(queue))
-	//assertEqual(t, 250, queue.Capacity())
+	// 244 = (101 + 21) * 2
+	assertEqual(t, 244, queue.Capacity())
 }
 
 func TestPopWholeQueue(t *testing.T) {
@@ -264,7 +264,7 @@ func TestPopWholeQueue(t *testing.T) {
 	queue.Push([]byte("c"))
 
 	// then
-	//assertEqual(t, 13, queue.Capacity())
+	assertEqual(t, 13, queue.Capacity())
 	assertEqual(t, []byte("c"), pop(queue))
 }
 
@@ -343,11 +343,12 @@ func TestMaxSizeLimit(t *testing.T) {
 	// when
 	queue.Push(blob('a', 25))
 	queue.Push(blob('b', 5))
-	//capacity := queue.Capacity()
-	//_, err := queue.Push(blob('c', 15))
+	capacity := queue.Capacity()
+	_, err := queue.Push(blob('c', 15))
+	assertEqual(t, err, nil)
+
 	// then
-	//assertEqual(t, 50, capacity)
-	//assertEqual(t, "Full queue. Maximum size limit reached.", err.Error())
+	assertEqual(t, 50, capacity)
 	assertEqual(t, blob('a', 25), pop(queue))
 	assertEqual(t, blob('b', 5), pop(queue))
 }

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -344,11 +344,11 @@ func TestMaxSizeLimit(t *testing.T) {
 	queue.Push(blob('a', 25))
 	queue.Push(blob('b', 5))
 	capacity := queue.Capacity()
-	_, err := queue.Push(blob('c', 15))
-	assertEqual(t, err, nil)
+	_, err := queue.Push(blob('c', 20))
 
 	// then
 	assertEqual(t, 50, capacity)
+	assertEqual(t, "Full queue. Maximum size limit reached.", err.Error())
 	assertEqual(t, blob('a', 25), pop(queue))
 	assertEqual(t, blob('b', 5), pop(queue))
 }


### PR DESCRIPTION
Hi there, I try to optimize bytes_queue in two ways:
1. The length is encoded in varint format(the assertion on capacity will fail so I commented them out).
2. When we insert an entry before the head of the queue, and the size of this entry exactly equals to unsued bytes, there is no need to reserve bytes. 

And below are the outputs of test on my Mac:
```
# Mine
2020/03/12 14:49:28 Allocated new queue in 130ns; Capacity: 88
2020/03/12 14:49:28 Allocated new queue in 211.918µs; Capacity: 585000
2020/03/12 14:49:28 Allocated new queue in 394.027µs; Capacity: 1170000
PASS
```

```
# Yours
2020/03/12 14:06:56 Allocated new queue in 156ns; Capacity: 94
2020/03/12 14:06:56 Allocated new queue in 719.26µs; Capacity: 585000
2020/03/12 14:06:56 Allocated new queue in 566.888µs; Capacity: 1170000
PASS
```

PS: It can save some bytes and avoid re-allocation of queue at some time