### PR TITLE
fix: can not resuce bytes queue

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -747,6 +747,46 @@ func TestOldestEntryDeletionWhenMaxCacheSizeIsReached(t *testing.T) {
 	assertEqual(t, blob('c', 1024*800), entry3)
 }
 
+func TestNewEntryWriteWhenMaxCacheSizeIsReached(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{
+		Shards:             1,
+		LifeWindow:         5 * time.Second,
+		MaxEntriesInWindow: 2,
+		MaxEntrySize:       400,
+		HardMaxCacheSize:   1,
+	})
+
+	// when
+	key1Err := cache.Set("key1", blob('a', 1024*400))
+	key2Err := cache.Set("key2", blob('b', 1024*400))
+	key3Err := cache.Set("key3", blob('c', 1024*400))
+	key4Err := cache.Set("key4", blob('d', 1024*400))
+
+
+	//then
+	noError(t,key1Err)
+	noError(t,key2Err)
+	noError(t,key3Err)
+	noError(t,key4Err)
+
+	// when
+	_, key1Err = cache.Get("key1")
+	_, key2Err = cache.Get("key2")
+	entry3, _ := cache.Get("key3")
+	entry4, _ := cache.Get("key4")
+
+	// then
+	assertEqual(t, key1Err, ErrEntryNotFound)
+	assertEqual(t, key2Err, ErrEntryNotFound)
+	assertEqual(t, blob('c', 1024*400), entry3)
+	assertEqual(t, blob('d', 1024*400), entry4)
+
+}
+
+
 func TestRetrievingEntryShouldCopy(t *testing.T) {
 	t.Parallel()
 

--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -22,7 +22,6 @@ var (
 // BytesQueue is a non-thread safe queue type of fifo based on bytes array.
 // For every push operation index of entry is returned. It can be used to read the entry later
 type BytesQueue struct {
-	full            bool
 	array           []byte
 	capacity        int
 	maxCapacity     int
@@ -78,7 +77,6 @@ func (q *BytesQueue) Reset() {
 	q.head = leftMarginIndex
 	q.rightMargin = leftMarginIndex
 	q.count = 0
-	q.full = false
 }
 
 // Push copies entry at the end of queue and moves tail pointer. Allocates more space if needed.
@@ -142,9 +140,6 @@ func (q *BytesQueue) push(data []byte, len int) {
 
 	if q.tail > q.head {
 		q.rightMargin = q.tail
-	}
-	if q.tail == q.head {
-		q.full = true
 	}
 
 	q.count++
@@ -238,9 +233,6 @@ func (q *BytesQueue) peek(index int) ([]byte, int, error) {
 
 // canInsertAfterTail returns true if it's possible to insert an entry of size of need after the tail of the queue
 func (q *BytesQueue) canInsertAfterTail(need int) bool {
-	if q.full {
-		return false
-	}
 	if q.tail >= q.head {
 		return q.capacity-q.tail >= need
 	}
@@ -253,9 +245,6 @@ func (q *BytesQueue) canInsertAfterTail(need int) bool {
 
 // canInsertBeforeHead returns true if it's possible to insert an entry of size of need before the head of the queue
 func (q *BytesQueue) canInsertBeforeHead(need int) bool {
-	if q.full {
-		return false
-	}
 	if q.tail >= q.head {
 		return q.head-leftMarginIndex == need || q.head-leftMarginIndex >= need+minimumHeaderSize
 	}

--- a/shard.go
+++ b/shard.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/allegro/bigcache/v2/queue"
+	"github.com/mangotree2/bigcache/queue"
 )
 
 type onRemoveCallback func(wrappedEntry []byte, reason RemoveReason)


### PR DESCRIPTION
fix this:
`
// given
	cache, _ := bigcache.NewBigCache(bigcache.Config{
		Shards:             1,
		LifeWindow:         5 * time.Second,
		MaxEntriesInWindow: 2,
		MaxEntrySize:       400,
		HardMaxCacheSize:   1,
		Verbose:true,
	})

	// when
	_ = cache.Set("key1", blob('a', 1024*400))
	_ = cache.Set("key2", blob('b', 1024*400))
	_ = cache.Set("key3", blob('c', 1024*400))
	key4Err := cache.Set("key4", blob('d', 1024*400))
	if key4Err != nil {
		panic(key4Err)
	}`