### PR TITLE
Deleted entries should not be removed by expire eviction

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -292,6 +292,10 @@ func (s *cacheShard) removeOldestEntry(reason RemoveReason) error {
 	oldest, err := s.entries.Pop()
 	if err == nil {
 		hash := readHashFromEntry(oldest)
+		if hash == 0 {
+			// entry has been explicitly deleted with resetKeyFromEntry, ignore
+			return nil
+		}
 		delete(s.hashmap, hash)
 		s.onRemove(oldest, reason)
 		if s.statsEnabled {


### PR DESCRIPTION
Hi, this is a small fix for #126,

I think the problem is that `shard.delete()` marks entries in queue as deleted ( by zero-ing all the 64 header bits for hash ), but `removeOldestEntry` is not checking for this case.