### PR TITLE
Reset full to false when pop from bytes queue

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -490,6 +490,33 @@ func TestCacheCapacity(t *testing.T) {
 	assertEqual(t, 40960, cache.Capacity())
 }
 
+func TestRemoveEntriesWhenShardIsFull(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(Config{
+		Shards:             1,
+		LifeWindow:         100 * time.Second,
+		MaxEntriesInWindow: 100,
+		MaxEntrySize:       256,
+		HardMaxCacheSize:   1,
+	})
+
+	value := blob('a', 1024*300)
+
+	// when
+	cache.Set("key", value)
+	cache.Set("key", value)
+	cache.Set("key", value)
+	cache.Set("key", value)
+	cache.Set("key", value)
+	cachedValue, err := cache.Get("key")
+
+	// then
+	noError(t, err)
+	assertEqual(t, value, cachedValue)
+}
+
 func TestCacheStats(t *testing.T) {
 	t.Parallel()
 

--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -173,6 +173,8 @@ func (q *BytesQueue) Pop() ([]byte, error) {
 		q.rightMargin = q.tail
 	}
 
+	q.full = false
+
 	return data, nil
 }
 


### PR DESCRIPTION
When byte queue is full, it will set `queue.full=true` but when evict and pop entry from queue, it does not set to false again. It causes bigcache cannot insert new entries once the queue is full.

This commit set `queue.full=false` when pop entry from queue, and add a test case which failed in current master https://github.com/allegro/bigcache/commit/ccdbc60304ad5ede288fea0a3d37ce4bae17b6db and passed in this commit.

Related to issue https://github.com/allegro/bigcache/issues/214
And it seems the same problem in Pull Request https://github.com/allegro/bigcache/pull/218
