### PR TITLE
Fix typo in comment for Metadata struct

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -10,7 +10,7 @@ import (
 
 type onRemoveCallback func(wrappedEntry []byte, reason RemoveReason)
 
-// Metadata contains information of a spesific entry
+// Metadata contains information of a specific entry
 type Metadata struct {
 	RequestCount uint32
 }


### PR DESCRIPTION
Just noticed this typo while reading through the docs.

Please let me know if there is anything else I need to do for this PR.