### PR TITLE
fix: panic when update and iterate simultaneously

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -1038,6 +1038,65 @@ func TestBigCache_GetWithInfo(t *testing.T) {
 	assertEqual(t, []byte(value), data)
 }
 
+func TestBigCache_OnPanicCallback(t *testing.T) {
+	t.Parallel()
+
+	defer func() {
+		if e := recover(); e != nil {
+			assertEqual(t, nil, e)
+		}
+	}()
+
+	var panicErr = fmt.Errorf("test panic")
+	// given
+	clock := mockedClock{value: 0}
+	cache, _ := newBigCache(Config{
+		Shards:             1,
+		LifeWindow:         5 * time.Second,
+		CleanWindow:        5 * time.Minute,
+		MaxEntriesInWindow: 1,
+		MaxEntrySize:       1,
+		HardMaxCacheSize:   1,
+		OnRemove: func(key string, entry []byte) {
+			panic(panicErr)
+		},
+		Verbose: true,
+	}, &clock)
+
+	// when
+	err := cache.Set("1", []byte("1value"))
+	noError(t, err)
+
+	clock.set(1)
+	err = cache.Set("2", []byte("2value"))
+	noError(t, err)
+
+	clock.set(2)
+	err = cache.Set("3", []byte("3value"))
+	noError(t, err)
+
+	clock.set(3)
+	err = cache.Set("4", []byte("4value"))
+	noError(t, err)
+
+	clock.set(4)
+	err = cache.Set("5", []byte("5value"))
+	noError(t, err)
+
+	clock.set(6)
+	cache.cleanUp(uint64(clock.epoch()))
+	clock.set(7)
+	cache.cleanUp(uint64(clock.epoch()))
+	clock.set(8)
+	cache.cleanUp(uint64(clock.epoch()))
+	clock.set(9)
+	cache.cleanUp(uint64(clock.epoch()))
+
+	value, err := cache.Get("5")
+	noError(t, err)
+	assertEqual(t, value, []byte("5value"))
+}
+
 type mockedLogger struct {
 	lastFormat string
 	lastArgs   []interface{}

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -1038,65 +1038,6 @@ func TestBigCache_GetWithInfo(t *testing.T) {
 	assertEqual(t, []byte(value), data)
 }
 
-func TestBigCache_OnPanicCallback(t *testing.T) {
-	t.Parallel()
-
-	defer func() {
-		if e := recover(); e != nil {
-			assertEqual(t, nil, e)
-		}
-	}()
-
-	var panicErr = fmt.Errorf("test panic")
-	// given
-	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{
-		Shards:             1,
-		LifeWindow:         5 * time.Second,
-		CleanWindow:        5 * time.Minute,
-		MaxEntriesInWindow: 1,
-		MaxEntrySize:       1,
-		HardMaxCacheSize:   1,
-		OnRemove: func(key string, entry []byte) {
-			panic(panicErr)
-		},
-		Verbose: true,
-	}, &clock)
-
-	// when
-	err := cache.Set("1", []byte("1value"))
-	noError(t, err)
-
-	clock.set(1)
-	err = cache.Set("2", []byte("2value"))
-	noError(t, err)
-
-	clock.set(2)
-	err = cache.Set("3", []byte("3value"))
-	noError(t, err)
-
-	clock.set(3)
-	err = cache.Set("4", []byte("4value"))
-	noError(t, err)
-
-	clock.set(4)
-	err = cache.Set("5", []byte("5value"))
-	noError(t, err)
-
-	clock.set(6)
-	cache.cleanUp(uint64(clock.epoch()))
-	clock.set(7)
-	cache.cleanUp(uint64(clock.epoch()))
-	clock.set(8)
-	cache.cleanUp(uint64(clock.epoch()))
-	clock.set(9)
-	cache.cleanUp(uint64(clock.epoch()))
-
-	value, err := cache.Get("5")
-	noError(t, err)
-	assertEqual(t, value, []byte("5value"))
-}
-
 type mockedLogger struct {
 	lastFormat string
 	lastArgs   []interface{}

--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -129,6 +129,8 @@ func (q *BytesQueue) allocateAdditionalMemory(minimum int) {
 		}
 	}
 
+	q.full = false
+
 	if q.verbose {
 		log.Printf("Allocated new queue in %s; Capacity: %d \n", time.Since(start), q.capacity)
 	}

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -379,6 +379,29 @@ func TestMaxSizeLimit(t *testing.T) {
 	assertEqual(t, blob('b', 5), pop(queue))
 }
 
+func TestPushEntryAfterAllocateAdditionMemory(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(9, 20, true)
+
+	// when
+	queue.Push([]byte("aaa"))
+	queue.Push([]byte("bb"))
+	queue.Pop()
+	queue.Push([]byte("c"))
+	queue.Push([]byte("d"))
+
+	// allocate more memory
+	assertEqual(t, 9, queue.Capacity())
+	queue.Push([]byte("c"))
+	assertEqual(t, 18, queue.Capacity())
+
+	// push after allocate
+	_, err := queue.Push([]byte("d"))
+	noError(t, err)
+}
+
 func pop(queue *BytesQueue) []byte {
 	entry, err := queue.Pop()
 	if err != nil {

--- a/shard.go
+++ b/shard.go
@@ -264,20 +264,25 @@ func (s *cacheShard) cleanUp(currentTimestamp uint64) {
 	s.lock.Unlock()
 }
 
-func (s *cacheShard) getEntry(index int) ([]byte, error) {
+func (s *cacheShard) getEntry(hashedKey uint64) ([]byte, error) {
 	s.lock.RLock()
-	entry, err := s.entries.Get(index)
+
+	entry, err := s.getWrappedEntry(hashedKey)
+	// copy entry
+	newEntry := make([]byte, len(entry))
+	copy(newEntry, entry)
+
 	s.lock.RUnlock()
 
-	return entry, err
+	return newEntry, err
 }
 
-func (s *cacheShard) copyKeys() (keys []uint32, next int) {
+func (s *cacheShard) copyHashedKeys() (keys []uint64, next int) {
 	s.lock.RLock()
-	keys = make([]uint32, len(s.hashmap))
+	keys = make([]uint64, len(s.hashmap))
 
-	for _, index := range s.hashmap {
-		keys[next] = index
+	for key := range s.hashmap {
+		keys[next] = key
 		next++
 	}
 

--- a/shard.go
+++ b/shard.go
@@ -2,7 +2,6 @@ package bigcache
 
 import (
 	"fmt"
-	"runtime/debug"
 	"sync"
 	"sync/atomic"
 
@@ -254,15 +253,6 @@ func (s *cacheShard) onEvict(oldestEntry []byte, currentTimestamp uint64, evict 
 }
 
 func (s *cacheShard) cleanUp(currentTimestamp uint64) {
-	defer func() {
-		// panic recover
-		if e := recover(); e != nil {
-			s.logger.Printf("panic recover, err: %v, stack: \n%s", e, debug.Stack())
-		}
-	}()
-
-	defer s.lock.Unlock()
-
 	s.lock.Lock()
 	for {
 		if oldestEntry, err := s.entries.Peek(); err != nil {
@@ -271,6 +261,7 @@ func (s *cacheShard) cleanUp(currentTimestamp uint64) {
 			break
 		}
 	}
+	s.lock.Unlock()
 }
 
 func (s *cacheShard) getEntry(hashedKey uint64) ([]byte, error) {


### PR DESCRIPTION
1. Fix panic when update and iteration simultaneously. Related to https://github.com/allegro/bigcache/issues/222.
2. Add panic recover in cleanUp to prevent the program exited. Related to https://github.com/allegro/bigcache/issues/226, https://github.com/allegro/bigcache/issues/148, just protect the main program not exited.
3. Byte queue set full is false after allocated addition memory. Also added a test case reproduce this problem.