### PR TITLE
Fixes race in getKeyMetadata accessor, when called from KeyMetadata

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -193,7 +193,7 @@ func (c *BigCache) Stats() Stats {
 func (c *BigCache) KeyMetadata(key string) Metadata {
 	hashedKey := c.hash.Sum64(key)
 	shard := c.getShard(hashedKey)
-	return shard.getKeyMetadata(hashedKey)
+	return shard.getKeyMetadataWithLock(hashedKey)
 }
 
 // Iterator returns iterator function to iterate over EntryInfo's from whole cache.

--- a/shard.go
+++ b/shard.go
@@ -341,6 +341,15 @@ func (s *cacheShard) getStats() Stats {
 	return stats
 }
 
+func (s *cacheShard) getKeyMetadataWithLock(key uint64) Metadata {
+	s.lock.RLock()
+	c := s.hashmapStats[key]
+	s.lock.RUnlock()
+	return Metadata{
+		RequestCount: c,
+	}
+}
+
 func (s *cacheShard) getKeyMetadata(key uint64) Metadata {
 	return Metadata{
 		RequestCount: s.hashmapStats[key],


### PR DESCRIPTION
All(?) cases where cacheShard.getKeyMetadata() was called were wrapped in a lock, except when KeyMetadata was used, resulting in a race between when a key was deleted via cacheShard.removeOldestEntry and read via cacheShard.getKeyMetadata().

```
WARNING: DATA RACE
Write at 0x00c01697d9b0 by goroutine 133:
  runtime.mapdelete_fast64()
      /home/m/Documents/workspace/go/src/runtime/map_fast64.go:272 +0x0
  github.com/allegro/bigcache/v2.(*cacheShard).removeOldestEntry()
      /home/m/gocode/src/github.com/cognusion/bigcache/shard.go:304 +0x360
  github.com/allegro/bigcache/v2.(*cacheShard).removeOldestEntry-fm()
      /home/m/gocode/src/github.com/cognusion/bigcache/shard.go:293 +0x49
  github.com/allegro/bigcache/v2.(*cacheShard).onEvict()
      /home/m/gocode/src/github.com/cognusion/bigcache/shard.go:249 +0x1cf
  github.com/allegro/bigcache/v2.(*cacheShard).cleanUp()
      /home/m/gocode/src/github.com/cognusion/bigcache/shard.go:260 +0xd8
  github.com/allegro/bigcache/v2.(*BigCache).cleanUp()
      /home/m/gocode/src/github.com/cognusion/bigcache/bigcache.go:215 +0x8b
  github.com/allegro/bigcache/v2.newBigCache.func1()
      /home/m/gocode/src/github.com/cognusion/bigcache/bigcache.go:92 +0xb4

Previous read at 0x00c01697d9b0 by goroutine 28:
  runtime.mapaccess1_fast64()
      /home/m/Documents/workspace/go/src/runtime/map_fast64.go:12 +0x0
  github.com/allegro/bigcache/v2.(*cacheShard).getKeyMetadata()
      /home/m/gocode/src/github.com/cognusion/bigcache/shard.go:348 +0x130
  github.com/allegro/bigcache/v2.(*BigCache).KeyMetadata()
      /home/m/gocode/src/github.com/cognusion/bigcache/bigcache.go:196 +0x14f
  github.com/allegro/bigcache/v2.TestWriteAndReadParallelSameKeyWithStats()
      /home/m/gocode/src/github.com/cognusion/bigcache/bigcache_test.go:699 +0x5f9
  testing.tRunner()
      /home/m/Documents/workspace/go/src/testing/testing.go:991 +0x1eb
```