### PR TITLE
Optimze append

### DIFF
--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -156,8 +156,9 @@ func appendToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsI
 
 		b.ReportAllocs()
 		for pb.Next() {
+			key := fmt.Sprintf("key-%d-%d", id, counter)
 			for j := 0; j < 7; j++ {
-				cache.Append(fmt.Sprintf("key-%d-%d", id, counter), message)
+				cache.Append(key, message)
 			}
 			counter = counter + 1
 		}

--- a/encoding.go
+++ b/encoding.go
@@ -68,6 +68,12 @@ func readKeyFromEntry(data []byte) string {
 	return bytesToString(dst)
 }
 
+func compareKeyFromEntry(data []byte, key string) bool {
+	length := binary.LittleEndian.Uint16(data[timestampSizeInBytes+hashSizeInBytes:])
+
+	return bytesToString(data[headersSizeInBytes:headersSizeInBytes+length]) == key
+}
+
 func readHashFromEntry(data []byte) uint64 {
 	return binary.LittleEndian.Uint64(data[timestampSizeInBytes:])
 }

--- a/encoding.go
+++ b/encoding.go
@@ -29,6 +29,21 @@ func wrapEntry(timestamp uint64, hash uint64, key string, entry []byte, buffer *
 	return blob[:blobLength]
 }
 
+func appendToWrappedEntry(timestamp uint64, wrappedEntry []byte, entry []byte, buffer *[]byte) []byte {
+	blobLength := len(wrappedEntry) + len(entry)
+	if blobLength > len(*buffer) {
+		*buffer = make([]byte, blobLength)
+	}
+
+	blob := *buffer
+
+	binary.LittleEndian.PutUint64(blob, timestamp)
+	copy(blob[timestampSizeInBytes:], wrappedEntry[timestampSizeInBytes:])
+	copy(blob[len(wrappedEntry):], entry)
+
+	return blob[:blobLength]
+}
+
 func readEntry(data []byte) []byte {
 	length := binary.LittleEndian.Uint16(data[timestampSizeInBytes+hashSizeInBytes:])
 

--- a/shard.go
+++ b/shard.go
@@ -104,7 +104,7 @@ func (s *cacheShard) getValidWrapEntry(key string, hashedKey uint64) ([]byte, er
 		return nil, err
 	}
 
-	if compareKeyFromEntry(wrappedEntry, key) {
+	if !compareKeyFromEntry(wrappedEntry, key) {
 		s.collision()
 		if s.isVerbose {
 			s.logger.Printf("Collision detected. Both %q and %q have the same hash %x", key, readKeyFromEntry(wrappedEntry), hashedKey)

--- a/shard.go
+++ b/shard.go
@@ -104,10 +104,10 @@ func (s *cacheShard) getValidWrapEntry(key string, hashedKey uint64) ([]byte, er
 		return nil, err
 	}
 
-	if entryKey := readKeyFromEntry(wrappedEntry); key != entryKey {
+	if compareKeyFromEntry(wrappedEntry, key) {
 		s.collision()
 		if s.isVerbose {
-			s.logger.Printf("Collision detected. Both %q and %q have the same hash %x", key, entryKey, hashedKey)
+			s.logger.Printf("Collision detected. Both %q and %q have the same hash %x", key, readKeyFromEntry(wrappedEntry), hashedKey)
 		}
 
 		return nil, ErrEntryNotFound

--- a/shard.go
+++ b/shard.go
@@ -81,24 +81,6 @@ func (s *cacheShard) get(key string, hashedKey uint64) ([]byte, error) {
 	return entry, nil
 }
 
-func (s *cacheShard) getWithoutLock(key string, hashedKey uint64) ([]byte, error) {
-	wrappedEntry, err := s.getWrappedEntry(hashedKey)
-	if err != nil {
-		return nil, err
-	}
-	if entryKey := readKeyFromEntry(wrappedEntry); key != entryKey {
-		s.collision()
-		if s.isVerbose {
-			s.logger.Printf("Collision detected. Both %q and %q have the same hash %x", key, entryKey, hashedKey)
-		}
-		return nil, ErrEntryNotFound
-	}
-	entry := readEntry(wrappedEntry)
-	s.hitWithoutLock(hashedKey)
-
-	return entry, nil
-}
-
 func (s *cacheShard) getWrappedEntry(hashedKey uint64) ([]byte, error) {
 	itemIndex := s.hashmap[hashedKey]
 
@@ -114,6 +96,25 @@ func (s *cacheShard) getWrappedEntry(hashedKey uint64) ([]byte, error) {
 	}
 
 	return wrappedEntry, err
+}
+
+func (s *cacheShard) getValidWrapEntry(key string, hashedKey uint64) ([]byte, error) {
+	wrappedEntry, err := s.getWrappedEntry(hashedKey)
+	if err != nil {
+		return nil, err
+	}
+
+	if entryKey := readKeyFromEntry(wrappedEntry); key != entryKey {
+		s.collision()
+		if s.isVerbose {
+			s.logger.Printf("Collision detected. Both %q and %q have the same hash %x", key, entryKey, hashedKey)
+		}
+
+		return nil, ErrEntryNotFound
+	}
+	s.hitWithoutLock(hashedKey)
+
+	return wrappedEntry, nil
 }
 
 func (s *cacheShard) set(key string, hashedKey uint64, entry []byte) error {
@@ -146,14 +147,8 @@ func (s *cacheShard) set(key string, hashedKey uint64, entry []byte) error {
 	}
 }
 
-func (s *cacheShard) setWithoutLock(key string, hashedKey uint64, entry []byte) error {
+func (s *cacheShard) addNewWithoutLock(key string, hashedKey uint64, entry []byte) error {
 	currentTimestamp := uint64(s.clock.Epoch())
-
-	if previousIndex := s.hashmap[hashedKey]; previousIndex != 0 {
-		if previousEntry, err := s.entries.Get(int(previousIndex)); err == nil {
-			resetKeyFromEntry(previousEntry)
-		}
-	}
 
 	if oldestEntry, err := s.entries.Peek(); err == nil {
 		s.onEvict(oldestEntry, currentTimestamp, s.removeOldestEntry)
@@ -172,22 +167,49 @@ func (s *cacheShard) setWithoutLock(key string, hashedKey uint64, entry []byte) 
 	}
 }
 
-func (s *cacheShard) append(key string, hashedKey uint64, entry []byte) error {
-	s.lock.Lock()
-	var newEntry []byte
-	oldEntry, err := s.getWithoutLock(key, hashedKey)
-	if err != nil {
-		if err != ErrEntryNotFound {
-			s.lock.Unlock()
-			return err
+func (s *cacheShard) setWrappedEntryWithoutLock(currentTimestamp uint64, w []byte, hashedKey uint64) error {
+	if previousIndex := s.hashmap[hashedKey]; previousIndex != 0 {
+		if previousEntry, err := s.entries.Get(int(previousIndex)); err == nil {
+			resetKeyFromEntry(previousEntry)
 		}
-	} else {
-		newEntry = oldEntry
 	}
 
-	newEntry = append(newEntry, entry...)
-	err = s.setWithoutLock(key, hashedKey, newEntry)
+	if oldestEntry, err := s.entries.Peek(); err == nil {
+		s.onEvict(oldestEntry, currentTimestamp, s.removeOldestEntry)
+	}
+
+	for {
+		if index, err := s.entries.Push(w); err == nil {
+			s.hashmap[hashedKey] = uint32(index)
+			return nil
+		}
+		if s.removeOldestEntry(NoSpace) != nil {
+			return fmt.Errorf("entry is bigger than max shard size")
+		}
+	}
+}
+
+func (s *cacheShard) append(key string, hashedKey uint64, entry []byte) error {
+	s.lock.Lock()
+	wrappedEntry, err := s.getValidWrapEntry(key, hashedKey)
+
+	if err == ErrEntryNotFound {
+		err = s.addNewWithoutLock(key, hashedKey, entry)
+		s.lock.Unlock()
+		return err
+	}
+	if err != nil {
+		s.lock.Unlock()
+		return err
+	}
+
+	currentTimestamp := uint64(s.clock.Epoch())
+
+	w := appendToWrappedEntry(currentTimestamp, wrappedEntry, entry, &s.entryBuffer)
+
+	err = s.setWrappedEntryWithoutLock(currentTimestamp, w, hashedKey)
 	s.lock.Unlock()
+
 	return err
 }
 


### PR DESCRIPTION
The append function is slow compared to the get and set method. The reason for this is that unnecessary copies of the data are done in the process. Namely, the `get` copy the data and the list `append` a second time. This leads to high allocation numbers and slow runtime overall.
In this PR the number of copies in the process is minimized without touching the `BytesQueue` logic. This reduces the allocs and halves the runtime of append without changing on the interface.
Some benchmarks result:
```
name                          old time/op    new time/op    delta
AppendToCache/1-shards-12       8.37µs ±26%    4.06µs ±23%  -51.48%  (p=0.000 n=99+98)
AppendToCache/512-shards-12     3.23µs ± 6%    1.87µs ± 3%  -42.00%  (p=0.000 n=96+92)
AppendToCache/1024-shards-12    3.49µs ± 4%    2.06µs ± 4%  -40.86%  (p=0.000 n=100+93)
AppendToCache/8192-shards-12    4.04µs ± 3%    2.85µs ± 3%  -29.42%  (p=0.000 n=96+97)

name                          old alloc/op   new alloc/op   delta
AppendToCache/1-shards-12       28.1kB ± 0%    14.1kB ± 0%  -49.84%  (p=0.000 n=100+100)
AppendToCache/512-shards-12     28.2kB ± 1%    14.1kB ± 0%  -49.92%  (p=0.000 n=93+95)
AppendToCache/1024-shards-12    29.4kB ± 4%    14.4kB ± 4%  -50.96%  (p=0.000 n=100+94)
AppendToCache/8192-shards-12    34.0kB ± 2%    19.4kB ± 3%  -43.07%  (p=0.000 n=99+98)

name                          old allocs/op  new allocs/op  delta
AppendToCache/1-shards-12         21.0 ± 0%       2.0 ± 0%  -90.48%  (p=0.000 n=100+100)
AppendToCache/512-shards-12       22.0 ± 0%       3.0 ± 0%  -86.36%  (p=0.000 n=100+100)
AppendToCache/1024-shards-12      22.0 ± 0%       3.0 ± 0%  -86.36%  (p=0.000 n=100+100)
AppendToCache/8192-shards-12      22.0 ± 0%       3.0 ± 0%  -86.36%  (p=0.000 n=100+100)

```