### PR TITLE
Fix a bug that obscures the byte queue when it is full and is extended

### DIFF
--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// Number of bytes to encode 0 in uvarint format
-	minimumHeaderSize = 1
+	minimumHeaderSize = 17 // 1 byte blobsize + timestampSizeInBytes + hashSizeInBytes
 	// Bytes before left margin are not used. Zero index means element does not exist in queue, useful while reading slice from index
 	leftMarginIndex = 1
 )

--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -118,10 +118,13 @@ func (q *BytesQueue) allocateAdditionalMemory(minimum int) {
 	if leftMarginIndex != q.rightMargin {
 		copy(q.array, oldArray[:q.rightMargin])
 
-		if q.tail < q.head {
-			headerEntrySize := getUvarintSize(uint32(q.head - q.tail))
-			emptyBlobLen := q.head - q.tail - headerEntrySize
-			q.push(make([]byte, emptyBlobLen), emptyBlobLen)
+		if q.tail <= q.head {
+			if q.tail != q.head {
+				headerEntrySize := getUvarintSize(uint32(q.head - q.tail))
+				emptyBlobLen := q.head - q.tail - headerEntrySize
+				q.push(make([]byte, emptyBlobLen), emptyBlobLen)
+			}
+
 			q.head = leftMarginIndex
 			q.tail = q.rightMargin
 		}

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -389,8 +389,6 @@ func TestPushEntryAfterAllocateAdditionMemory(t *testing.T) {
 	queue.Push([]byte("aaa"))
 	queue.Push([]byte("bb"))
 	queue.Pop()
-	queue.Push([]byte("c"))
-	queue.Push([]byte("d"))
 
 	// allocate more memory
 	assertEqual(t, 9, queue.Capacity())

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -402,6 +402,30 @@ func TestPushEntryAfterAllocateAdditionMemory(t *testing.T) {
 	noError(t, err)
 }
 
+func TestPushEntryAfterAllocateAdditionMemoryInFull(t *testing.T) {
+	t.Parallel()
+
+	// given
+	queue := NewBytesQueue(9, 40, true)
+
+	// when
+	queue.Push([]byte("aaa"))
+	queue.Push([]byte("bb"))
+	_, err := queue.Pop()
+	noError(t, err)
+
+	queue.Push([]byte("c"))
+	queue.Push([]byte("d"))
+	queue.Push([]byte("e"))
+	_, err = queue.Pop()
+	noError(t, err)
+	_, err = queue.Pop()
+	noError(t, err)
+	queue.Push([]byte("fff"))
+	_, err = queue.Pop()
+	noError(t, err)
+}
+
 func pop(queue *BytesQueue) []byte {
 	entry, err := queue.Pop()
 	if err != nil {


### PR DESCRIPTION
Hi,
On searching for the reason for the panics in the current version where versions pre 2.2 works well, I think I have found the cause. 
With PR #207 it gets possible that the byte queen is full and `q.tail == q.head`. However, in the `allocateAdditionalMemory` method, the condition for resetting head and tail is `q.tail < q.head`. Thus the tail and head are not changed, and the byte queen is obscured after it. An example that leads to panic in the old logic is shown in the test `TestPushEntryAfterAllocateAdditionMemoryInFull`.

This is a different reason for panics then #236, so I am not sure which of the reported panic ( #226 #234 #235 ) is caused by this bug.