### PR TITLE
Skip hashing

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -113,8 +113,7 @@ func (c *BigCache) Close() error {
 // no entry exists for the given key.
 func (c *BigCache) Get(key string) ([]byte, error) {
 	hashedKey := c.hash.Sum64(key)
-	shard := c.getShard(hashedKey)
-	return shard.get(key, hashedKey)
+	return c.GetByHash(key, hashedKey)
 }
 
 // GetByHash reads entry for the hashed key.
@@ -130,8 +129,7 @@ func (c *BigCache) GetByHash(key string, hashedKey uint64) ([]byte, error) {
 // no entry exists for the given key.
 func (c *BigCache) GetWithInfo(key string) ([]byte, Response, error) {
 	hashedKey := c.hash.Sum64(key)
-	shard := c.getShard(hashedKey)
-	return shard.getWithInfo(key, hashedKey)
+	return c.GetWithInfoByHash(key, hashedKey)
 }
 
 // GetWithInfoByHash reads entry for the hashed key with Response info.
@@ -145,8 +143,7 @@ func (c *BigCache) GetWithInfoByHash(key string, hashedKey uint64) ([]byte, Resp
 // Set saves entry under the key
 func (c *BigCache) Set(key string, entry []byte) error {
 	hashedKey := c.hash.Sum64(key)
-	shard := c.getShard(hashedKey)
-	return shard.set(key, hashedKey, entry)
+	return c.SetByHash(key, hashedKey, entry)
 }
 
 // SetByHash saves entry under the hashed key
@@ -160,8 +157,7 @@ func (c *BigCache) SetByHash(key string, hashedKey uint64, entry []byte) error {
 // concatenate multiple entries under the same key in an lock optimized way.
 func (c *BigCache) Append(key string, entry []byte) error {
 	hashedKey := c.hash.Sum64(key)
-	shard := c.getShard(hashedKey)
-	return shard.append(key, hashedKey, entry)
+	return c.AppendByHash(key, hashedKey, entry)
 }
 
 // AppendByHash appends entry under the hashed key if hashed key exists, otherwise
@@ -175,8 +171,7 @@ func (c *BigCache) AppendByHash(key string, hashedKey uint64, entry []byte) erro
 // Delete removes the key
 func (c *BigCache) Delete(key string) error {
 	hashedKey := c.hash.Sum64(key)
-	shard := c.getShard(hashedKey)
-	return shard.del(hashedKey)
+	return c.DeleteByHash(hashedKey)
 }
 
 // DeleteByHash removes the hashed key
@@ -228,8 +223,7 @@ func (c *BigCache) Stats() Stats {
 // KeyMetadata returns number of times a cached resource was requested.
 func (c *BigCache) KeyMetadata(key string) Metadata {
 	hashedKey := c.hash.Sum64(key)
-	shard := c.getShard(hashedKey)
-	return shard.getKeyMetadataWithLock(hashedKey)
+	return c.KeyMetadataByHash(hashedKey)
 }
 
 // KeyMetadataByHash returns number of times a cached resource was requested.

--- a/bigcache.go
+++ b/bigcache.go
@@ -117,6 +117,14 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 	return shard.get(key, hashedKey)
 }
 
+// Get reads entry for the hashed key.
+// It returns an ErrEntryNotFound when
+// no entry exists for the given hashed key.
+func (c *BigCache) GetByHash(key string, hashedKey uint64) ([]byte, error) {
+	shard := c.getShard(hashedKey)
+	return shard.get(key, hashedKey)
+}
+
 // GetWithInfo reads entry for the key with Response info.
 // It returns an ErrEntryNotFound when
 // no entry exists for the given key.
@@ -126,9 +134,23 @@ func (c *BigCache) GetWithInfo(key string) ([]byte, Response, error) {
 	return shard.getWithInfo(key, hashedKey)
 }
 
+// GetWithInfo reads entry for the hashed key with Response info.
+// It returns an ErrEntryNotFound when
+// no entry exists for the given hashed key.
+func (c *BigCache) GetWithInfoByHash(key string, hashedKey uint64) ([]byte, Response, error) {
+	shard := c.getShard(hashedKey)
+	return shard.getWithInfo(key, hashedKey)
+}
+
 // Set saves entry under the key
 func (c *BigCache) Set(key string, entry []byte) error {
 	hashedKey := c.hash.Sum64(key)
+	shard := c.getShard(hashedKey)
+	return shard.set(key, hashedKey, entry)
+}
+
+// Set saves entry under the hashed key
+func (c *BigCache) SetByHash(key string, hashedKey uint64, entry []byte) error {
 	shard := c.getShard(hashedKey)
 	return shard.set(key, hashedKey, entry)
 }
@@ -142,9 +164,23 @@ func (c *BigCache) Append(key string, entry []byte) error {
 	return shard.append(key, hashedKey, entry)
 }
 
+// Append appends entry under the hashed key if hashed key exists, otherwise
+// it will set the key (same behaviour as Set()). With Append() you can
+// concatenate multiple entries under the same hashed key in an lock optimized way.
+func (c *BigCache) AppendByHash(key string, hashedKey uint64, entry []byte) error {
+	shard := c.getShard(hashedKey)
+	return shard.append(key, hashedKey, entry)
+}
+
 // Delete removes the key
 func (c *BigCache) Delete(key string) error {
 	hashedKey := c.hash.Sum64(key)
+	shard := c.getShard(hashedKey)
+	return shard.del(hashedKey)
+}
+
+// Delete removes the hashed key
+func (c *BigCache) DeleteByHash(hashedKey uint64) error {
 	shard := c.getShard(hashedKey)
 	return shard.del(hashedKey)
 }
@@ -192,6 +228,12 @@ func (c *BigCache) Stats() Stats {
 // KeyMetadata returns number of times a cached resource was requested.
 func (c *BigCache) KeyMetadata(key string) Metadata {
 	hashedKey := c.hash.Sum64(key)
+	shard := c.getShard(hashedKey)
+	return shard.getKeyMetadataWithLock(hashedKey)
+}
+
+// KeyMetadata returns number of times a cached resource was requested.
+func (c *BigCache) KeyMetadataByHash(hashedKey uint64) Metadata {
 	shard := c.getShard(hashedKey)
 	return shard.getKeyMetadataWithLock(hashedKey)
 }

--- a/bigcache.go
+++ b/bigcache.go
@@ -117,7 +117,7 @@ func (c *BigCache) Get(key string) ([]byte, error) {
 	return shard.get(key, hashedKey)
 }
 
-// Get reads entry for the hashed key.
+// GetByHash reads entry for the hashed key.
 // It returns an ErrEntryNotFound when
 // no entry exists for the given hashed key.
 func (c *BigCache) GetByHash(key string, hashedKey uint64) ([]byte, error) {
@@ -134,7 +134,7 @@ func (c *BigCache) GetWithInfo(key string) ([]byte, Response, error) {
 	return shard.getWithInfo(key, hashedKey)
 }
 
-// GetWithInfo reads entry for the hashed key with Response info.
+// GetWithInfoByHash reads entry for the hashed key with Response info.
 // It returns an ErrEntryNotFound when
 // no entry exists for the given hashed key.
 func (c *BigCache) GetWithInfoByHash(key string, hashedKey uint64) ([]byte, Response, error) {
@@ -149,7 +149,7 @@ func (c *BigCache) Set(key string, entry []byte) error {
 	return shard.set(key, hashedKey, entry)
 }
 
-// Set saves entry under the hashed key
+// SetByHash saves entry under the hashed key
 func (c *BigCache) SetByHash(key string, hashedKey uint64, entry []byte) error {
 	shard := c.getShard(hashedKey)
 	return shard.set(key, hashedKey, entry)
@@ -164,8 +164,8 @@ func (c *BigCache) Append(key string, entry []byte) error {
 	return shard.append(key, hashedKey, entry)
 }
 
-// Append appends entry under the hashed key if hashed key exists, otherwise
-// it will set the key (same behaviour as Set()). With Append() you can
+// AppendByHash appends entry under the hashed key if hashed key exists, otherwise
+// it will set the key (same behaviour as SetByHash()). With AppendByHash() you can
 // concatenate multiple entries under the same hashed key in an lock optimized way.
 func (c *BigCache) AppendByHash(key string, hashedKey uint64, entry []byte) error {
 	shard := c.getShard(hashedKey)
@@ -179,7 +179,7 @@ func (c *BigCache) Delete(key string) error {
 	return shard.del(hashedKey)
 }
 
-// Delete removes the hashed key
+// DeleteByHash removes the hashed key
 func (c *BigCache) DeleteByHash(hashedKey uint64) error {
 	shard := c.getShard(hashedKey)
 	return shard.del(hashedKey)
@@ -232,7 +232,7 @@ func (c *BigCache) KeyMetadata(key string) Metadata {
 	return shard.getKeyMetadataWithLock(hashedKey)
 }
 
-// KeyMetadata returns number of times a cached resource was requested.
+// KeyMetadataByHash returns number of times a cached resource was requested.
 func (c *BigCache) KeyMetadataByHash(hashedKey uint64) Metadata {
 	shard := c.getShard(hashedKey)
 	return shard.getKeyMetadataWithLock(hashedKey)

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -1065,6 +1065,22 @@ func TestBigCache_GetWithInfo(t *testing.T) {
 	assertEqual(t, []byte(value), data)
 }
 
+func TestCacheOperationsByHash(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := NewBigCache(DefaultConfig(5 * time.Second))
+	value := []byte("value")
+
+	// when
+	cache.SetByHash("key", 1, value)
+	cachedValue, err := cache.GetByHash("key", 1)
+
+	// then
+	noError(t, err)
+	assertEqual(t, value, cachedValue)
+}
+
 type mockedLogger struct {
 	lastFormat string
 	lastArgs   []interface{}


### PR DESCRIPTION
I need a way to provide my own hash value without string to uint64 conversion.
I think the simplest solution is to provide setter and getter with the ability to skip hashing.