### PR TITLE
Update readme to version 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requires Go 1.12 or newer.
 ### Simple initialization
 
 ```go
-import "github.com/allegro/bigcache"
+import "github.com/allegro/bigcache/v2"
 
 cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(10 * time.Minute))
 
@@ -30,7 +30,7 @@ allocation can be avoided in that way.
 import (
 	"log"
 
-	"github.com/allegro/bigcache"
+	"github.com/allegro/bigcache/v2"
 )
 
 config := bigcache.Config {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Requires Go 1.12 or newer.
 ### Simple initialization
 
 ```go
-import "github.com/allegro/bigcache/v2"
+import "github.com/allegro/bigcache/v3"
 
 cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(10 * time.Minute))
 
@@ -30,7 +30,7 @@ allocation can be avoided in that way.
 import (
 	"log"
 
-	"github.com/allegro/bigcache/v2"
+	"github.com/allegro/bigcache/v3"
 )
 
 config := bigcache.Config {


### PR DESCRIPTION
We had some memory leaks in production. after further investigations, we found out that we were using big cache v1 (which interestingly HardMaxCacheSize is not working properly). I'm sure if we don't change it to version 2 it will cause some confusion.