### PR TITLE
Fix error where config.Shards = 0 causes "index out of range"

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -990,6 +990,7 @@ func TestClosing(t *testing.T) {
 	// given
 	config := Config{
 		CleanWindow: time.Minute,
+		Shards: 1,
 	}
 	startGR := runtime.NumGoroutine()
 

--- a/utils.go
+++ b/utils.go
@@ -19,5 +19,5 @@ func convertMBToBytes(value int) int {
 }
 
 func isPowerOfTwo(number int) bool {
-	return (number & (number - 1)) == 0
+	return (number != 0) && (number & (number - 1)) == 0
 }


### PR DESCRIPTION
Issue Fixed:

If config.Shards is set to 0 then an "index out of range" error will be generated by bigcache.GetShard() at _bigcache.go:220_

> runtime error: index out of range [6004679098338124500] with length 0
goroutine 98 [running]:
net/http.(*conn).serve.func1(0xc00016c000)
        /usr/lib/go-1.13/src/net/http/server.go:1767 +0x139
panic(0xa5e780, 0xc000166160)
        /usr/lib/go-1.13/src/runtime/panic.go:679 +0x1b2
github.com/allegro/bigcache.(*BigCache).getShard(...)
        ...github.com/allegro/bigcache/bigcache.go:220

`func (c *BigCache) getShard(hashedKey uint64) (shard *cacheShard) {
	return c.shards[hashedKey&c.shardMask]
}`

As the isPowerofTwo() check considers 0 a power of two.

Test:

TestClosing (bicache_test.go) failed because it didn't specify a number of Shards in its config.

All tests pass with the minor change to TestClosing.