### PR TITLE
fix HardMaxCacheSize documentation

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,10 +22,13 @@ type Config struct {
 	Verbose bool
 	// Hasher used to map between string keys and unsigned 64bit integers, by default fnv64 hashing is used.
 	Hasher Hasher
-	// HardMaxCacheSize is a limit for cache size in MB. Cache will not allocate more memory than this limit.
+	// HardMaxCacheSize is a limit for BytesQueue size in MB.
 	// It can protect application from consuming all available memory on machine, therefore from running OOM Killer.
 	// Default value is 0 which means unlimited size. When the limit is higher than 0 and reached then
-	// the oldest entries are overridden for the new ones.
+	// the oldest entries are overridden for the new ones. The max memory consumption will be bigger than
+	// HardMaxCacheSize due to Shards' s additional memory. Every Shard consumes additional memory for map of keys
+	// and statistics (map[uint64]uint32) the size of this map is equal to number of entries in
+	// cache ~ 2×(64+32)×n bits + overhead or map itself.
 	HardMaxCacheSize int
 	// OnRemove is a callback fired when the oldest entry is removed because of its expiration time or no space left
 	// for the new entry, or because delete was called.


### PR DESCRIPTION
As #292 has pointed out, the documentation has misleading message for HardMaxCacheSize. 

To solve it, this PR modifies the HardMaxCacheSize comment.