### PR TITLE
Fix bug to remove non-expired data

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -209,6 +209,9 @@ func (c *BigCache) Iterator() *EntryInfoIterator {
 
 func (c *BigCache) onEvict(oldestEntry []byte, currentTimestamp uint64, evict func(reason RemoveReason) error) bool {
 	oldestTimestamp := readTimestampFromEntry(oldestEntry)
+	if currentTimestamp < oldestTimestamp {
+		return false
+	}
 	if currentTimestamp-oldestTimestamp > c.lifeWindow {
 		evict(Expired)
 		return true

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -1188,10 +1188,9 @@ func TestBigCache_allocateAdditionalMemoryLeadPanic(t *testing.T) {
 	assertEqual(t, []byte{0xff, 0xff, 0xff}, data)
 }
 
-func TestRemoveExpired(t *testing.T) {
+func TestRemoveNonExpiredData(t *testing.T) {
 	onRemove := func(key string, entry []byte, reason RemoveReason) {
 		if reason != Deleted {
-			//处理落地
 			if reason == Expired {
 				t.Errorf("[%d]Expired OnRemove [%s]\n", reason, key)
 				t.FailNow()

--- a/shard.go
+++ b/shard.go
@@ -269,6 +269,9 @@ func (s *cacheShard) del(hashedKey uint64) error {
 
 func (s *cacheShard) onEvict(oldestEntry []byte, currentTimestamp uint64, evict func(reason RemoveReason) error) bool {
 	oldestTimestamp := readTimestampFromEntry(oldestEntry)
+	if currentTimestamp < oldestTimestamp {
+		return false
+	}
 	if currentTimestamp-oldestTimestamp > s.lifeWindow {
 		evict(Expired)
 		return true


### PR DESCRIPTION
Sometimes an error occurs to remove non-expired data when "currentTimestamp" is less than "oldestTimestamp"