### PR TITLE
[Question] shard.getWrappedEntry Method return arguments

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -95,7 +95,7 @@ func (s *cacheShard) getWrappedEntry(hashedKey uint64) ([]byte, error) {
 		return nil, err
 	}
 
-	return wrappedEntry, err
+	return wrappedEntry, nil
 }
 
 func (s *cacheShard) getValidWrapEntry(key string, hashedKey uint64) ([]byte, error) {


### PR DESCRIPTION
How about return nil instead of err?

```go
// shard.go

func (s *cacheShard) getWrappedEntry(hashedKey uint64) ([]byte, error) {
	itemIndex := s.hashmap[hashedKey]

	if itemIndex == 0 {
		s.miss()
		return nil, ErrEntryNotFound
	}

	wrappedEntry, err := s.entries.Get(int(itemIndex))
	if err != nil {
		s.miss()
		return nil, err
	}

       //return wrappedEntry, err
       return wrappedEntry, nil 
}
`