### PR TITLE
[question] Add After Expired test to GetWithInfo Test

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -1099,6 +1099,12 @@ func TestBigCache_GetWithInfo(t *testing.T) {
 			wantData: value,
 			wantResp: Response{},
 		},
+		{
+			name:     "After Expired",
+			clock:    6,
+			wantData: value,
+			wantResp: Response{EntryStatus: Expired},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			clock.set(tc.clock)


### PR DESCRIPTION
This test covers the following lines 

```go
// shard.go
func (s *cacheShard) getWithInfo(key string, hashedKey uint64) (entry []byte, resp Response, err error) {
        ...
	if s.isExpired(wrappedEntry, currentTime) {
		resp.EntryStatus = Expired
	}
        ...
}
```