### PR TITLE
Cleanly shutdown cleanup go-routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ Requires Go 1.12 or newer.
 ### Simple initialization
 
 ```go
-import "github.com/allegro/bigcache/v3"
+import (
+	"fmt"
+	"context"
+	"github.com/allegro/bigcache/v3"
+)
 
-cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(10 * time.Minute))
+cache, _ := bigcache.NewBigCache(context.TODO(), bigcache.DefaultConfig(10 * time.Minute))
 
 cache.Set("my-unique-key", []byte("value"))
 
@@ -71,7 +75,7 @@ config := bigcache.Config {
 		OnRemoveWithReason: nil,
 	}
 
-cache, initErr := bigcache.NewBigCache(config)
+cache, initErr := bigcache.NewBigCache(context.TODO(), config)
 if initErr != nil {
 	log.Fatal(initErr)
 }

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import (
 	"github.com/allegro/bigcache/v3"
 )
 
-cache, _ := bigcache.NewBigCache(context.TODO(), bigcache.DefaultConfig(10 * time.Minute))
+cache, _ := bigcache.New(context.Background(), bigcache.DefaultConfig(10 * time.Minute))
 
 cache.Set("my-unique-key", []byte("value"))
 
@@ -75,7 +75,7 @@ config := bigcache.Config {
 		OnRemoveWithReason: nil,
 	}
 
-cache, initErr := bigcache.NewBigCache(context.TODO(), config)
+cache, initErr := bigcache.New(context.Background(), config)
 if initErr != nil {
 	log.Fatal(initErr)
 }

--- a/bigcache.go
+++ b/bigcache.go
@@ -41,9 +41,18 @@ const (
 	Deleted = RemoveReason(3)
 )
 
-// NewBigCache initialize new instance of BigCache
-func NewBigCache(ctx context.Context, config Config) (*BigCache, error) {
+// New initialize new instance of BigCache
+func New(ctx context.Context, config Config) (*BigCache, error) {
 	return newBigCache(ctx, config, &systemClock{})
+}
+
+// NewBigCache initialize new instance of BigCache
+//
+// Deprecated: NewBigCache is deprecated, please use New(ctx, config) instead,
+// New takes in context and can gracefully
+// shutdown with context cancellations
+func NewBigCache(config Config) (*BigCache, error) {
+	return newBigCache(context.Background(), config, &systemClock{})
 }
 
 func newBigCache(ctx context.Context, config Config, clock clock) (*BigCache, error) {

--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkWriteToCacheWith1Shard(b *testing.B) {
 
 func BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 	m := blob('a', 1024)
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         100 * time.Second,
 		MaxEntriesInWindow: 100,
@@ -33,7 +33,7 @@ func BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 
 func BenchmarkWriteToUnlimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 	m := blob('a', 1024)
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         100 * time.Second,
 		MaxEntriesInWindow: 100,
@@ -82,7 +82,7 @@ func BenchmarkIterateOverCache(b *testing.B) {
 
 	for _, shards := range []int{512, 1024, 8192} {
 		b.Run(fmt.Sprintf("%d-shards", shards), func(b *testing.B) {
-			cache, _ := NewBigCache(context.TODO(), Config{
+			cache, _ := New(context.Background(), Config{
 				Shards:             shards,
 				LifeWindow:         1000 * time.Second,
 				MaxEntriesInWindow: max(b.N, 100),
@@ -122,7 +122,7 @@ func BenchmarkReadFromCacheNonExistentKeys(b *testing.B) {
 }
 
 func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsInLifeWindow int) {
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             shards,
 		LifeWindow:         lifeWindow,
 		MaxEntriesInWindow: max(requestsInLifeWindow, 100),
@@ -143,7 +143,7 @@ func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsIn
 }
 
 func appendToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsInLifeWindow int) {
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             shards,
 		LifeWindow:         lifeWindow,
 		MaxEntriesInWindow: max(requestsInLifeWindow, 100),
@@ -167,7 +167,7 @@ func appendToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsI
 }
 
 func readFromCache(b *testing.B, shards int, info bool) {
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             shards,
 		LifeWindow:         1000 * time.Second,
 		MaxEntriesInWindow: max(b.N, 100),
@@ -192,7 +192,7 @@ func readFromCache(b *testing.B, shards int, info bool) {
 }
 
 func readFromCacheNonExistentKeys(b *testing.B, shards int) {
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             shards,
 		LifeWindow:         1000 * time.Second,
 		MaxEntriesInWindow: max(b.N, 100),

--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -1,6 +1,7 @@
 package bigcache
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -16,7 +17,7 @@ func BenchmarkWriteToCacheWith1Shard(b *testing.B) {
 
 func BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 	m := blob('a', 1024)
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         100 * time.Second,
 		MaxEntriesInWindow: 100,
@@ -32,7 +33,7 @@ func BenchmarkWriteToLimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 
 func BenchmarkWriteToUnlimitedCacheWithSmallInitSizeAnd1Shard(b *testing.B) {
 	m := blob('a', 1024)
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         100 * time.Second,
 		MaxEntriesInWindow: 100,
@@ -81,7 +82,7 @@ func BenchmarkIterateOverCache(b *testing.B) {
 
 	for _, shards := range []int{512, 1024, 8192} {
 		b.Run(fmt.Sprintf("%d-shards", shards), func(b *testing.B) {
-			cache, _ := NewBigCache(Config{
+			cache, _ := NewBigCache(context.TODO(), Config{
 				Shards:             shards,
 				LifeWindow:         1000 * time.Second,
 				MaxEntriesInWindow: max(b.N, 100),
@@ -121,7 +122,7 @@ func BenchmarkReadFromCacheNonExistentKeys(b *testing.B) {
 }
 
 func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsInLifeWindow int) {
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             shards,
 		LifeWindow:         lifeWindow,
 		MaxEntriesInWindow: max(requestsInLifeWindow, 100),
@@ -142,7 +143,7 @@ func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsIn
 }
 
 func appendToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsInLifeWindow int) {
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             shards,
 		LifeWindow:         lifeWindow,
 		MaxEntriesInWindow: max(requestsInLifeWindow, 100),
@@ -166,7 +167,7 @@ func appendToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsI
 }
 
 func readFromCache(b *testing.B, shards int, info bool) {
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             shards,
 		LifeWindow:         1000 * time.Second,
 		MaxEntriesInWindow: max(b.N, 100),
@@ -191,7 +192,7 @@ func readFromCache(b *testing.B, shards int, info bool) {
 }
 
 func readFromCacheNonExistentKeys(b *testing.B, shards int) {
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             shards,
 		LifeWindow:         1000 * time.Second,
 		MaxEntriesInWindow: max(b.N, 100),

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -2,6 +2,7 @@ package bigcache
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -16,7 +17,7 @@ func TestWriteAndGetOnCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(DefaultConfig(5 * time.Second))
+	cache, _ := NewBigCache(context.TODO(), DefaultConfig(5*time.Second))
 	value := []byte("value")
 
 	// when
@@ -32,7 +33,7 @@ func TestAppendAndGetOnCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(DefaultConfig(5 * time.Second))
+	cache, _ := NewBigCache(context.TODO(), DefaultConfig(5*time.Second))
 	key := "key"
 	value1 := make([]byte, 50)
 	rand.Read(value1)
@@ -93,7 +94,7 @@ func TestAppendRandomly(t *testing.T) {
 		HardMaxCacheSize:   1,
 		Logger:             DefaultLogger(),
 	}
-	cache, err := NewBigCache(c)
+	cache, err := NewBigCache(context.TODO(), c)
 	noError(t, err)
 
 	nKeys := 5
@@ -145,7 +146,7 @@ func TestAppendCollision(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -178,7 +179,7 @@ func TestConstructCacheWithDefaultHasher(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             16,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -214,7 +215,7 @@ func TestNewBigcacheValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.want, func(t *testing.T) {
-			cache, error := NewBigCache(tc.cfg)
+			cache, error := NewBigCache(context.TODO(), tc.cfg)
 
 			assertEqual(t, (*BigCache)(nil), cache)
 			assertEqual(t, tc.want, error.Error())
@@ -226,7 +227,7 @@ func TestEntryNotFound(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             16,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -245,7 +246,7 @@ func TestTimingEviction(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -276,7 +277,7 @@ func TestTimingEvictionShouldEvictOnlyFromUpdatedShard(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:             4,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -298,7 +299,7 @@ func TestCleanShouldEvictAll(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             4,
 		LifeWindow:         time.Second,
 		CleanWindow:        time.Second,
@@ -331,7 +332,7 @@ func TestOnRemoveCallback(t *testing.T) {
 	onRemoveExt := func(key string, entry []byte, reason RemoveReason) {
 		onRemoveExtInvoked = true
 	}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -362,7 +363,7 @@ func TestOnRemoveWithReasonCallback(t *testing.T) {
 		assertEqual(t, []byte("value"), entry)
 		assertEqual(t, reason, RemoveReason(Expired))
 	}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -396,7 +397,7 @@ func TestOnRemoveFilter(t *testing.T) {
 		OnRemoveWithReason: onRemove,
 	}.OnRemoveFilterSet(Deleted, NoSpace)
 
-	cache, _ := newBigCache(c, &clock)
+	cache, _ := newBigCache(context.TODO(), c, &clock)
 
 	// when
 	cache.Set("key", []byte("value"))
@@ -439,7 +440,7 @@ func TestOnRemoveFilterExpired(t *testing.T) {
 		OnRemoveWithReason: onRemove,
 	}
 
-	cache, err := newBigCache(c, &clock)
+	cache, err := newBigCache(context.TODO(), c, &clock)
 	assertEqual(t, err, nil)
 
 	// case 1: key is deleted AFTER expire
@@ -492,7 +493,7 @@ func TestOnRemoveGetEntryStats(t *testing.T) {
 		StatsEnabled:         true,
 	}.OnRemoveFilterSet(Deleted, NoSpace)
 
-	cache, _ := newBigCache(c, &clock)
+	cache, _ := newBigCache(context.TODO(), c, &clock)
 
 	// when
 	cache.Set("key", []byte("value"))
@@ -511,7 +512,7 @@ func TestCacheLen(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -532,7 +533,7 @@ func TestCacheCapacity(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -554,7 +555,7 @@ func TestCacheInitialCapacity(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 2 * 1024,
@@ -581,7 +582,7 @@ func TestRemoveEntriesWhenShardIsFull(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         100 * time.Second,
 		MaxEntriesInWindow: 100,
@@ -608,7 +609,7 @@ func TestCacheStats(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -649,7 +650,7 @@ func TestCacheEntryStats(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -673,7 +674,7 @@ func TestCacheRestStats(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -722,7 +723,7 @@ func TestCacheDel(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(DefaultConfig(time.Second))
+	cache, _ := NewBigCache(context.TODO(), DefaultConfig(time.Second))
 
 	// when
 	err := cache.Delete("nonExistingKey")
@@ -757,7 +758,7 @@ func TestCacheDelRandomly(t *testing.T) {
 		Logger:             DefaultLogger(),
 	}
 
-	cache, _ := NewBigCache(c)
+	cache, _ := NewBigCache(context.TODO(), c)
 	var wg sync.WaitGroup
 	var ntest = 800000
 	wg.Add(3)
@@ -808,7 +809,7 @@ func TestWriteAndReadParallelSameKeyWithStats(t *testing.T) {
 	c := DefaultConfig(0)
 	c.StatsEnabled = true
 
-	cache, _ := NewBigCache(c)
+	cache, _ := NewBigCache(context.TODO(), c)
 	var wg sync.WaitGroup
 	ntest := 1000
 	n := 10
@@ -839,7 +840,7 @@ func TestCacheReset(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -874,7 +875,7 @@ func TestIterateOnResetCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -898,7 +899,7 @@ func TestGetOnResetCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -925,7 +926,7 @@ func TestEntryUpdate(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         6 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -948,7 +949,7 @@ func TestOldestEntryDeletionWhenMaxCacheSizeIsReached(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -975,7 +976,7 @@ func TestRetrievingEntryShouldCopy(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -1001,7 +1002,7 @@ func TestEntryBiggerThanMaxShardSizeError(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -1021,7 +1022,7 @@ func TestHashCollision(t *testing.T) {
 
 	ml := &mockedLogger{}
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             16,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -1062,7 +1063,7 @@ func TestNilValueCaching(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -1105,7 +1106,7 @@ func TestClosing(t *testing.T) {
 
 	// when
 	for i := 0; i < 100; i++ {
-		cache, _ := NewBigCache(config)
+		cache, _ := NewBigCache(context.TODO(), config)
 		cache.Close()
 	}
 
@@ -1123,7 +1124,7 @@ func TestEntryNotPresent(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -1144,7 +1145,7 @@ func TestBigCache_GetWithInfo(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		CleanWindow:        5 * time.Minute,
@@ -1203,7 +1204,7 @@ func TestBigCache_GetWithInfoCollision(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -1263,7 +1264,7 @@ func TestCache_SetWithoutCleanWindow(t *testing.T) {
 	opt := DefaultConfig(time.Second)
 	opt.CleanWindow = 0
 	opt.HardMaxCacheSize = 1
-	bc, _ := NewBigCache(opt)
+	bc, _ := NewBigCache(context.TODO(), opt)
 
 	err := bc.Set("2225", make([]byte, 200))
 	if nil != err {
@@ -1272,7 +1273,6 @@ func TestCache_SetWithoutCleanWindow(t *testing.T) {
 	}
 }
 
-//
 func TestCache_RepeatedSetWithBiggerEntry(t *testing.T) {
 
 	opt := DefaultConfig(time.Second)
@@ -1280,7 +1280,7 @@ func TestCache_RepeatedSetWithBiggerEntry(t *testing.T) {
 	opt.MaxEntriesInWindow = 1024
 	opt.MaxEntrySize = 1
 	opt.HardMaxCacheSize = 1
-	bc, _ := NewBigCache(opt)
+	bc, _ := NewBigCache(context.TODO(), opt)
 
 	err := bc.Set("2225", make([]byte, 200))
 	if nil != err {
@@ -1318,7 +1318,7 @@ func TestCache_RepeatedSetWithBiggerEntry(t *testing.T) {
 func TestBigCache_allocateAdditionalMemoryLeadPanic(t *testing.T) {
 	t.Parallel()
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:       1,
 		LifeWindow:   3 * time.Second,
 		MaxEntrySize: 52,
@@ -1367,7 +1367,7 @@ func TestRemoveNonExpiredData(t *testing.T) {
 	config.MaxEntrySize = 1024
 	config.MaxEntriesInWindow = 1024
 	config.OnRemoveWithReason = onRemove
-	cache, err := NewBigCache(config)
+	cache, err := NewBigCache(context.TODO(), config)
 	noError(t, err)
 	defer func() {
 		err := cache.Close()

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -17,7 +17,7 @@ func TestWriteAndGetOnCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), DefaultConfig(5*time.Second))
+	cache, _ := New(context.Background(), DefaultConfig(5*time.Second))
 	value := []byte("value")
 
 	// when
@@ -33,7 +33,7 @@ func TestAppendAndGetOnCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), DefaultConfig(5*time.Second))
+	cache, _ := New(context.Background(), DefaultConfig(5*time.Second))
 	key := "key"
 	value1 := make([]byte, 50)
 	rand.Read(value1)
@@ -94,7 +94,7 @@ func TestAppendRandomly(t *testing.T) {
 		HardMaxCacheSize:   1,
 		Logger:             DefaultLogger(),
 	}
-	cache, err := NewBigCache(context.TODO(), c)
+	cache, err := New(context.Background(), c)
 	noError(t, err)
 
 	nKeys := 5
@@ -146,7 +146,7 @@ func TestAppendCollision(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -179,7 +179,7 @@ func TestConstructCacheWithDefaultHasher(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             16,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -215,7 +215,7 @@ func TestNewBigcacheValidation(t *testing.T) {
 		},
 	} {
 		t.Run(tc.want, func(t *testing.T) {
-			cache, error := NewBigCache(context.TODO(), tc.cfg)
+			cache, error := New(context.Background(), tc.cfg)
 
 			assertEqual(t, (*BigCache)(nil), cache)
 			assertEqual(t, tc.want, error.Error())
@@ -227,7 +227,7 @@ func TestEntryNotFound(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             16,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -246,7 +246,7 @@ func TestTimingEviction(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -277,7 +277,7 @@ func TestTimingEvictionShouldEvictOnlyFromUpdatedShard(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:             4,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -299,7 +299,7 @@ func TestCleanShouldEvictAll(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             4,
 		LifeWindow:         time.Second,
 		CleanWindow:        time.Second,
@@ -332,7 +332,7 @@ func TestOnRemoveCallback(t *testing.T) {
 	onRemoveExt := func(key string, entry []byte, reason RemoveReason) {
 		onRemoveExtInvoked = true
 	}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -363,7 +363,7 @@ func TestOnRemoveWithReasonCallback(t *testing.T) {
 		assertEqual(t, []byte("value"), entry)
 		assertEqual(t, reason, RemoveReason(Expired))
 	}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -397,7 +397,7 @@ func TestOnRemoveFilter(t *testing.T) {
 		OnRemoveWithReason: onRemove,
 	}.OnRemoveFilterSet(Deleted, NoSpace)
 
-	cache, _ := newBigCache(context.TODO(), c, &clock)
+	cache, _ := newBigCache(context.Background(), c, &clock)
 
 	// when
 	cache.Set("key", []byte("value"))
@@ -440,7 +440,7 @@ func TestOnRemoveFilterExpired(t *testing.T) {
 		OnRemoveWithReason: onRemove,
 	}
 
-	cache, err := newBigCache(context.TODO(), c, &clock)
+	cache, err := newBigCache(context.Background(), c, &clock)
 	assertEqual(t, err, nil)
 
 	// case 1: key is deleted AFTER expire
@@ -493,7 +493,7 @@ func TestOnRemoveGetEntryStats(t *testing.T) {
 		StatsEnabled:         true,
 	}.OnRemoveFilterSet(Deleted, NoSpace)
 
-	cache, _ := newBigCache(context.TODO(), c, &clock)
+	cache, _ := newBigCache(context.Background(), c, &clock)
 
 	// when
 	cache.Set("key", []byte("value"))
@@ -512,7 +512,7 @@ func TestCacheLen(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -533,7 +533,7 @@ func TestCacheCapacity(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -555,7 +555,7 @@ func TestCacheInitialCapacity(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 2 * 1024,
@@ -582,7 +582,7 @@ func TestRemoveEntriesWhenShardIsFull(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         100 * time.Second,
 		MaxEntriesInWindow: 100,
@@ -609,7 +609,7 @@ func TestCacheStats(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -650,7 +650,7 @@ func TestCacheEntryStats(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -674,7 +674,7 @@ func TestCacheRestStats(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -723,7 +723,7 @@ func TestCacheDel(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), DefaultConfig(time.Second))
+	cache, _ := New(context.Background(), DefaultConfig(time.Second))
 
 	// when
 	err := cache.Delete("nonExistingKey")
@@ -758,7 +758,7 @@ func TestCacheDelRandomly(t *testing.T) {
 		Logger:             DefaultLogger(),
 	}
 
-	cache, _ := NewBigCache(context.TODO(), c)
+	cache, _ := New(context.Background(), c)
 	var wg sync.WaitGroup
 	var ntest = 800000
 	wg.Add(3)
@@ -809,7 +809,7 @@ func TestWriteAndReadParallelSameKeyWithStats(t *testing.T) {
 	c := DefaultConfig(0)
 	c.StatsEnabled = true
 
-	cache, _ := NewBigCache(context.TODO(), c)
+	cache, _ := New(context.Background(), c)
 	var wg sync.WaitGroup
 	ntest := 1000
 	n := 10
@@ -840,7 +840,7 @@ func TestCacheReset(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -875,7 +875,7 @@ func TestIterateOnResetCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -899,7 +899,7 @@ func TestGetOnResetCache(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -926,7 +926,7 @@ func TestEntryUpdate(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         6 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -949,7 +949,7 @@ func TestOldestEntryDeletionWhenMaxCacheSizeIsReached(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -976,7 +976,7 @@ func TestRetrievingEntryShouldCopy(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -1002,7 +1002,7 @@ func TestEntryBiggerThanMaxShardSizeError(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -1022,7 +1022,7 @@ func TestHashCollision(t *testing.T) {
 
 	ml := &mockedLogger{}
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             16,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -1063,7 +1063,7 @@ func TestNilValueCaching(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -1106,7 +1106,7 @@ func TestClosing(t *testing.T) {
 
 	// when
 	for i := 0; i < 100; i++ {
-		cache, _ := NewBigCache(context.TODO(), config)
+		cache, _ := New(context.Background(), config)
 		cache.Close()
 	}
 
@@ -1124,7 +1124,7 @@ func TestEntryNotPresent(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -1145,7 +1145,7 @@ func TestBigCache_GetWithInfo(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		CleanWindow:        5 * time.Minute,
@@ -1204,7 +1204,7 @@ func TestBigCache_GetWithInfoCollision(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         5 * time.Second,
 		MaxEntriesInWindow: 10,
@@ -1264,7 +1264,7 @@ func TestCache_SetWithoutCleanWindow(t *testing.T) {
 	opt := DefaultConfig(time.Second)
 	opt.CleanWindow = 0
 	opt.HardMaxCacheSize = 1
-	bc, _ := NewBigCache(context.TODO(), opt)
+	bc, _ := New(context.Background(), opt)
 
 	err := bc.Set("2225", make([]byte, 200))
 	if nil != err {
@@ -1280,7 +1280,7 @@ func TestCache_RepeatedSetWithBiggerEntry(t *testing.T) {
 	opt.MaxEntriesInWindow = 1024
 	opt.MaxEntrySize = 1
 	opt.HardMaxCacheSize = 1
-	bc, _ := NewBigCache(context.TODO(), opt)
+	bc, _ := New(context.Background(), opt)
 
 	err := bc.Set("2225", make([]byte, 200))
 	if nil != err {
@@ -1318,7 +1318,7 @@ func TestCache_RepeatedSetWithBiggerEntry(t *testing.T) {
 func TestBigCache_allocateAdditionalMemoryLeadPanic(t *testing.T) {
 	t.Parallel()
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:       1,
 		LifeWindow:   3 * time.Second,
 		MaxEntrySize: 52,
@@ -1367,7 +1367,7 @@ func TestRemoveNonExpiredData(t *testing.T) {
 	config.MaxEntrySize = 1024
 	config.MaxEntriesInWindow = 1024
 	config.OnRemoveWithReason = onRemove
-	cache, err := NewBigCache(context.TODO(), config)
+	cache, err := New(context.Background(), config)
 	noError(t, err)
 	defer func() {
 		err := cache.Close()

--- a/examples_test.go
+++ b/examples_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func Example() {
-	cache, _ := bigcache.NewBigCache(context.TODO(), bigcache.DefaultConfig(10*time.Minute))
+	cache, _ := bigcache.New(context.Background(), bigcache.DefaultConfig(10*time.Minute))
 
 	cache.Set("my-unique-key", []byte("value"))
 
@@ -60,7 +60,7 @@ func Example_custom() {
 		OnRemoveWithReason: nil,
 	}
 
-	cache, initErr := bigcache.NewBigCache(context.TODO(), config)
+	cache, initErr := bigcache.New(context.Background(), config)
 	if initErr != nil {
 		log.Fatal(initErr)
 	}

--- a/examples_test.go
+++ b/examples_test.go
@@ -1,6 +1,7 @@
 package bigcache_test
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"time"
@@ -9,7 +10,7 @@ import (
 )
 
 func Example() {
-	cache, _ := bigcache.NewBigCache(bigcache.DefaultConfig(10 * time.Minute))
+	cache, _ := bigcache.NewBigCache(context.TODO(), bigcache.DefaultConfig(10*time.Minute))
 
 	cache.Set("my-unique-key", []byte("value"))
 
@@ -59,7 +60,7 @@ func Example_custom() {
 		OnRemoveWithReason: nil,
 	}
 
-	cache, initErr := bigcache.NewBigCache(config)
+	cache, initErr := bigcache.NewBigCache(context.TODO(), config)
 	if initErr != nil {
 		log.Fatal(initErr)
 	}

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -16,7 +16,7 @@ func TestEntriesIterator(t *testing.T) {
 
 	// given
 	keysCount := 1000
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         6 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -49,7 +49,7 @@ func TestEntriesIteratorWithMostShardsEmpty(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(Config{
+	cache, _ := newBigCache(context.TODO(), Config{
 		Shards:             8,
 		LifeWindow:         6 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -80,7 +80,7 @@ func TestEntriesIteratorWithConcurrentUpdate(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -122,7 +122,7 @@ func TestEntriesIteratorWithAllShardsEmpty(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -142,7 +142,7 @@ func TestEntriesIteratorInInvalidState(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -159,7 +159,7 @@ func TestEntriesIteratorInInvalidState(t *testing.T) {
 }
 
 func TestEntriesIteratorParallelAdd(t *testing.T) {
-	bc, err := NewBigCache(DefaultConfig(1 * time.Minute))
+	bc, err := NewBigCache(context.TODO(), DefaultConfig(1*time.Minute))
 	if err != nil {
 		panic(err)
 	}
@@ -192,7 +192,7 @@ func TestParallelSetAndIteration(t *testing.T) {
 
 	rand.Seed(0)
 
-	cache, _ := NewBigCache(Config{
+	cache, _ := NewBigCache(context.TODO(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 100,

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -16,7 +16,7 @@ func TestEntriesIterator(t *testing.T) {
 
 	// given
 	keysCount := 1000
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         6 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -49,7 +49,7 @@ func TestEntriesIteratorWithMostShardsEmpty(t *testing.T) {
 
 	// given
 	clock := mockedClock{value: 0}
-	cache, _ := newBigCache(context.TODO(), Config{
+	cache, _ := newBigCache(context.Background(), Config{
 		Shards:             8,
 		LifeWindow:         6 * time.Second,
 		MaxEntriesInWindow: 1,
@@ -80,7 +80,7 @@ func TestEntriesIteratorWithConcurrentUpdate(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -122,7 +122,7 @@ func TestEntriesIteratorWithAllShardsEmpty(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -142,7 +142,7 @@ func TestEntriesIteratorInInvalidState(t *testing.T) {
 	t.Parallel()
 
 	// given
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 1,
@@ -159,7 +159,7 @@ func TestEntriesIteratorInInvalidState(t *testing.T) {
 }
 
 func TestEntriesIteratorParallelAdd(t *testing.T) {
-	bc, err := NewBigCache(context.TODO(), DefaultConfig(1*time.Minute))
+	bc, err := New(context.Background(), DefaultConfig(1*time.Minute))
 	if err != nil {
 		panic(err)
 	}
@@ -192,7 +192,7 @@ func TestParallelSetAndIteration(t *testing.T) {
 
 	rand.Seed(0)
 
-	cache, _ := NewBigCache(context.TODO(), Config{
+	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
 		MaxEntriesInWindow: 100,

--- a/server/server.go
+++ b/server/server.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -67,7 +68,7 @@ func main() {
 	}
 
 	var err error
-	cache, err = bigcache.NewBigCache(config)
+	cache, err = bigcache.NewBigCache(context.TODO(), config)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	var err error
-	cache, err = bigcache.NewBigCache(context.TODO(), config)
+	cache, err = bigcache.New(context.Background(), config)
 	if err != nil {
 		logger.Fatal(err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -17,7 +18,7 @@ const (
 )
 
 func testCacheSetup() {
-	cache, _ = bigcache.NewBigCache(bigcache.Config{
+	cache, _ = bigcache.NewBigCache(context.TODO(), bigcache.Config{
 		Shards:             1024,
 		LifeWindow:         10 * time.Minute,
 		MaxEntriesInWindow: 1000 * 10 * 60,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -18,7 +18,7 @@ const (
 )
 
 func testCacheSetup() {
-	cache, _ = bigcache.NewBigCache(context.TODO(), bigcache.Config{
+	cache, _ = bigcache.New(context.Background(), bigcache.Config{
 		Shards:             1024,
 		LifeWindow:         10 * time.Minute,
 		MaxEntriesInWindow: 1000 * 10 * 60,


### PR DESCRIPTION
Cleanly shutdown go routine. Big cache was made when go did not have ctx support

Fixes https://github.com/allegro/bigcache/issues/336