### PR TITLE
Use errors.New instead of fmt.Errorf

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -2,6 +2,7 @@ package bigcache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 )
@@ -57,16 +58,16 @@ func NewBigCache(config Config) (*BigCache, error) {
 
 func newBigCache(ctx context.Context, config Config, clock clock) (*BigCache, error) {
 	if !isPowerOfTwo(config.Shards) {
-		return nil, fmt.Errorf("Shards number must be power of two")
+		return nil, errors.New("Shards number must be power of two")
 	}
 	if config.MaxEntrySize < 0 {
-		return nil, fmt.Errorf("MaxEntrySize must be >= 0")
+		return nil, errors.New("MaxEntrySize must be >= 0")
 	}
 	if config.MaxEntriesInWindow < 0 {
-		return nil, fmt.Errorf("MaxEntriesInWindow must be >= 0")
+		return nil, errors.New("MaxEntriesInWindow must be >= 0")
 	}
 	if config.HardMaxCacheSize < 0 {
-		return nil, fmt.Errorf("HardMaxCacheSize must be >= 0")
+		return nil, errors.New("HardMaxCacheSize must be >= 0")
 	}
 
 	if config.Hasher == nil {

--- a/shard.go
+++ b/shard.go
@@ -1,7 +1,7 @@
 package bigcache
 
 import (
-	"fmt"
+	"errors"
 	"sync"
 	"sync/atomic"
 
@@ -146,7 +146,7 @@ func (s *cacheShard) set(key string, hashedKey uint64, entry []byte) error {
 		}
 		if s.removeOldestEntry(NoSpace) != nil {
 			s.lock.Unlock()
-			return fmt.Errorf("entry is bigger than max shard size")
+			return errors.New("entry is bigger than max shard size")
 		}
 	}
 }
@@ -168,7 +168,7 @@ func (s *cacheShard) addNewWithoutLock(key string, hashedKey uint64, entry []byt
 			return nil
 		}
 		if s.removeOldestEntry(NoSpace) != nil {
-			return fmt.Errorf("entry is bigger than max shard size")
+			return errors.New("entry is bigger than max shard size")
 		}
 	}
 }
@@ -192,7 +192,7 @@ func (s *cacheShard) setWrappedEntryWithoutLock(currentTimestamp uint64, w []byt
 			return nil
 		}
 		if s.removeOldestEntry(NoSpace) != nil {
-			return fmt.Errorf("entry is bigger than max shard size")
+			return errors.New("entry is bigger than max shard size")
 		}
 	}
 }


### PR DESCRIPTION
`errors.New` is more efficient than `fmt.Errorf` when format arg is not required