### PR TITLE
changed to uint64 keys

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -16,7 +16,7 @@ type Metadata struct {
 }
 
 type cacheShard struct {
-	hashmap     map[uint64]uint32
+	hashmap     map[uint64]uint64
 	entries     queue.BytesQueue
 	lock        sync.RWMutex
 	entryBuffer []byte
@@ -140,7 +140,7 @@ func (s *cacheShard) set(key string, hashedKey uint64, entry []byte) error {
 
 	for {
 		if index, err := s.entries.Push(w); err == nil {
-			s.hashmap[hashedKey] = uint32(index)
+			s.hashmap[hashedKey] = uint64(index)
 			s.lock.Unlock()
 			return nil
 		}
@@ -164,7 +164,7 @@ func (s *cacheShard) addNewWithoutLock(key string, hashedKey uint64, entry []byt
 
 	for {
 		if index, err := s.entries.Push(w); err == nil {
-			s.hashmap[hashedKey] = uint32(index)
+			s.hashmap[hashedKey] = uint64(index)
 			return nil
 		}
 		if s.removeOldestEntry(NoSpace) != nil {
@@ -188,7 +188,7 @@ func (s *cacheShard) setWrappedEntryWithoutLock(currentTimestamp uint64, w []byt
 
 	for {
 		if index, err := s.entries.Push(w); err == nil {
-			s.hashmap[hashedKey] = uint32(index)
+			s.hashmap[hashedKey] = uint64(index)
 			return nil
 		}
 		if s.removeOldestEntry(NoSpace) != nil {
@@ -347,7 +347,7 @@ func (s *cacheShard) removeOldestEntry(reason RemoveReason) error {
 
 func (s *cacheShard) reset(config Config) {
 	s.lock.Lock()
-	s.hashmap = make(map[uint64]uint32, config.initialShardSize())
+	s.hashmap = make(map[uint64]uint64, config.initialShardSize())
 	s.entryBuffer = make([]byte, config.MaxEntrySize+headersSizeInBytes)
 	s.entries.Reset()
 	s.lock.Unlock()
@@ -438,7 +438,7 @@ func initNewShard(config Config, callback onRemoveCallback, clock clock) *cacheS
 		bytesQueueInitialCapacity = maximumShardSizeInBytes
 	}
 	return &cacheShard{
-		hashmap:      make(map[uint64]uint32, config.initialShardSize()),
+		hashmap:      make(map[uint64]uint64, config.initialShardSize()),
 		hashmapStats: make(map[uint64]uint32, config.initialShardSize()),
 		entries:      *queue.NewBytesQueue(bytesQueueInitialCapacity, maximumShardSizeInBytes, config.Verbose),
 		entryBuffer:  make([]byte, config.MaxEntrySize+headersSizeInBytes),


### PR DESCRIPTION
closes  #354 

was trying to run benchmarks however when using uint32 keys i consistently ran into slice bounds out of range errors as seen below:

`BenchmarkAppendToCache/1-shards-12       panic: runtime error: slice bounds out of range [98993:98992]`