### PR TITLE
Get multiple cached values

### DIFF
--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -69,6 +69,67 @@ func BenchmarkReadFromCache(b *testing.B) {
 	}
 }
 
+func BenchmarkReadFromCacheManySingle(b *testing.B) {
+    for _, shards := range []int{1, 512, 1024, 8192} {
+		b.Run(fmt.Sprintf("%d-shards", shards), func(b *testing.B) {
+			cache, _ := New(context.Background(), Config{
+				Shards:             shards,
+				LifeWindow:         1000 * time.Second,
+				MaxEntriesInWindow: max(b.N, 100),
+				MaxEntrySize:       500,
+			})
+
+            keys := make([]string,b.N)
+			for i := 0; i < b.N; i++ {
+                keys[i] = fmt.Sprintf("key-%d", i)
+				cache.Set(keys[i], message)
+			}
+
+            b.ReportAllocs()
+            b.ResetTimer()
+            for _,key := range keys {
+                cache.Get(key) 
+            }
+
+		})
+	}
+}
+
+
+func BenchmarkReadFromCacheManyMulti(b *testing.B) {
+	for _, shards := range []int{1, 512, 1024, 8192} {
+        for _, batchSize := range []int{1, 5, 10, 100} {
+            b.Run(fmt.Sprintf("%d-shards %d-batchSize", shards,batchSize), func(b *testing.B) {
+                cache, _ := New(context.Background(), Config{
+                    Shards:             shards,
+                    LifeWindow:         1000 * time.Second,
+                    MaxEntriesInWindow: max(b.N, 100),
+                    MaxEntrySize:       500,
+                })
+                keys := make([]string,b.N)
+                for i := 0; i < b.N; i++ {
+                    keys[i] = fmt.Sprintf("key-%d", i)
+                    cache.Set(keys[i], message)
+                }
+                
+                batches := make([][]string, 0, (len(keys) + batchSize - 1) / batchSize)
+
+                for batchSize < len(keys) {
+                    keys, batches = keys[batchSize:], append(batches, keys[0:batchSize:batchSize])
+                }
+                batches = append(batches, keys)
+
+                b.ReportAllocs()
+                b.ResetTimer()
+                for _,b := range batches{
+                    cache.GetMulti(b)
+                    
+                }
+            })
+        }
+    }
+}
+
 func BenchmarkReadFromCacheWithInfo(b *testing.B) {
 	for _, shards := range []int{1, 512, 1024, 8192} {
 		b.Run(fmt.Sprintf("%d-shards", shards), func(b *testing.B) {

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -29,6 +29,28 @@ func TestWriteAndGetOnCache(t *testing.T) {
 	assertEqual(t, value, cachedValue)
 }
 
+func TestWriteAndGetOnCacheMulti(t *testing.T) {
+	t.Parallel()
+
+	// given
+	cache, _ := New(context.Background(), DefaultConfig(5*time.Second))
+    keys := []string{"k1","k2","k3","k4","k5"}
+	values := [][]byte{[]byte("v1"),[]byte("v2"),[]byte("v3"),[]byte("v4"),[]byte("v5")}
+
+	// when
+    for i,key := range keys{
+        cache.Set(key,values[i])
+    }
+	cachedValues, err := cache.GetMulti(keys)
+
+	// then
+	noError(t, err)
+
+    for i,cachedValue := range cachedValues{
+        assertEqual(t,values[i],cachedValue)
+    }
+}
+
 func TestAppendAndGetOnCache(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #324

It works but it's not always faster, the sweet spot where the multi is faster seems to be using 512 shards. I tried using batches and getting all keys at once.

see benchmark stats below: 
```
goos: linux
goarch: amd64
pkg: github.com/allegro/bigcache/v3
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkReadFromCacheManySingle/1-shards-12    22697095               209.2 ns/op           271 B/op          2 allocs/op
BenchmarkReadFromCacheManySingle/512-shards-12          22677458               390.5 ns/op           271 B/op          2 allocs/op
BenchmarkReadFromCacheManySingle/1024-shards-12         21077452               292.2 ns/op           271 B/op          2 allocs/op
BenchmarkReadFromCacheManySingle/8192-shards-12         14678848               358.9 ns/op           271 B/op          2 allocs/op
BenchmarkReadFromCacheManyMulti/1-shards-12             17450160               379.8 ns/op           391 B/op          4 allocs/op
BenchmarkReadFromCacheManyMulti/512-shards-12           13122825               352.7 ns/op           391 B/op          3 allocs/op
BenchmarkReadFromCacheManyMulti/1024-shards-12          12371637               452.6 ns/op           391 B/op          3 allocs/op
BenchmarkReadFromCacheManyMulti/8192-shards-12          10217793               510.0 ns/op           391 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/1-shards_1-batchSize-12          16625830               304.9 ns/op           311 B/op          4 allocs/op
BenchmarkReadFromCacheManyMultiBatches/1-shards_5-batchSize-12          18745413               331.4 ns/op           313 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/1-shards_10-batchSize-12         18708693               320.4 ns/op           311 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/1-shards_100-batchSize-12        18868872               301.9 ns/op           314 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/512-shards_1-batchSize-12        14753187               324.6 ns/op           311 B/op          4 allocs/op
BenchmarkReadFromCacheManyMultiBatches/512-shards_5-batchSize-12        16509196               307.5 ns/op           313 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/512-shards_10-batchSize-12       16936620               302.9 ns/op           311 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/512-shards_100-batchSize-12      16388095               308.3 ns/op           314 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/1024-shards_1-batchSize-12       14036588               366.8 ns/op           311 B/op          4 allocs/op
BenchmarkReadFromCacheManyMultiBatches/1024-shards_5-batchSize-12       16088242               336.3 ns/op           313 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/1024-shards_10-batchSize-12      15999337               322.7 ns/op           311 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/1024-shards_100-batchSize-12     16596691               328.2 ns/op           314 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/8192-shards_1-batchSize-12        9646165               495.1 ns/op           311 B/op          4 allocs/op
BenchmarkReadFromCacheManyMultiBatches/8192-shards_5-batchSize-12       11869656               453.4 ns/op           313 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/8192-shards_10-batchSize-12      11936322               451.0 ns/op           311 B/op          3 allocs/op
BenchmarkReadFromCacheManyMultiBatches/8192-shards_100-batchSize-12     11719633               446.0 ns/op           314 B/op          3 allocs/op
PASS
ok      github.com/allegro/bigcache/v3  321.286s

```