### PR TITLE
check LifeWindow when CleanWindow is set

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -70,13 +70,18 @@ func newBigCache(ctx context.Context, config Config, clock clock) (*BigCache, er
 		return nil, errors.New("HardMaxCacheSize must be >= 0")
 	}
 
+	lifeWindowSeconds := uint64(config.LifeWindow.Seconds())
+	if config.CleanWindow > 0 && lifeWindowSeconds == 0 {
+		return nil, errors.New("LifeWindow must be >= 1s when CleanWindow is set")
+	}
+
 	if config.Hasher == nil {
 		config.Hasher = newDefaultHasher()
 	}
 
 	cache := &BigCache{
 		shards:     make([]*cacheShard, config.Shards),
-		lifeWindow: uint64(config.LifeWindow.Seconds()),
+		lifeWindow: lifeWindowSeconds,
 		clock:      clock,
 		hash:       config.Hasher,
 		config:     config,

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -806,7 +806,7 @@ func TestCacheDelRandomly(t *testing.T) {
 func TestWriteAndReadParallelSameKeyWithStats(t *testing.T) {
 	t.Parallel()
 
-	c := DefaultConfig(0)
+	c := DefaultConfig(10 * time.Second)
 	c.StatsEnabled = true
 
 	cache, _ := New(context.Background(), c)
@@ -1101,6 +1101,7 @@ func TestClosing(t *testing.T) {
 	config := Config{
 		CleanWindow: time.Minute,
 		Shards:      1,
+		LifeWindow:  1 * time.Second,
 	}
 	startGR := runtime.NumGoroutine()
 


### PR DESCRIPTION
When set CleanWindow, if LifeWindow isn't set, any data you put in will be wiped out right away. So, we need to add a check to prevent this.