### PR TITLE
Revert change to how expiration timings to calculated.

### DIFF
--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -256,7 +256,6 @@ func TestTimingEviction(t *testing.T) {
 	cache.Set("key", []byte("value"))
 
 	// when
-	clock.set(1)
 	cache.Set("key2", []byte("value2"))
 	_, err := cache.Get("key")
 
@@ -1181,7 +1180,7 @@ func TestBigCache_GetWithInfo(t *testing.T) {
 			name:     "Expired",
 			clock:    5,
 			wantData: value,
-			wantResp: Response{},
+			wantResp: Response{EntryStatus: Expired},
 		},
 		{
 			name:     "After Expired",

--- a/shard.go
+++ b/shard.go
@@ -286,7 +286,7 @@ func (s *cacheShard) isExpired(oldestEntry []byte, currentTimestamp uint64) bool
 	if currentTimestamp <= oldestTimestamp { // if currentTimestamp < oldestTimestamp, the result will out of uint64 limits;
 		return false
 	}
-	return currentTimestamp-oldestTimestamp > s.lifeWindow
+	return currentTimestamp-oldestTimestamp >= s.lifeWindow
 }
 
 func (s *cacheShard) cleanUp(currentTimestamp uint64) {


### PR DESCRIPTION
When testing upgrading from [v3.0.2](https://github.com/allegro/bigcache/releases/tag/v3.0.2) to [v3.1.0](https://github.com/allegro/bigcache/releases/tag/v3.1.0), I've noticed a small bug impactful (to me) change around how expirations are calculated.

If you set a `LifeWindow` of `1s`, add an entry, and wait 1100ms, the entry does not expire. Testing it a bit more, I've discovered that it actually expires if you wait `2s`.

You can see this regression in code when comparing the old logic [here](https://github.com/allegro/bigcache/compare/v3.0.2...v3.1.0#diff-61374e089aecc0446ef16b857ce1b251d3231aa4dc9658c3d78c28f3525138fcL56) with the new logic [here](https://github.com/allegro/bigcache/compare/v3.0.2...v3.1.0#diff-61374e089aecc0446ef16b857ce1b251d3231aa4dc9658c3d78c28f3525138fcR289).

For convenience, old logic:

```golang
if currentTime-oldestTimeStamp >= s.lifeWindow {
}
```

new logic:

```golang
return currentTimestamp-oldestTimestamp > s.lifeWindow
```