### PR TITLE
Improve error handling in BytesQueue.Push function in queue.go

### DIFF
--- a/queue/bytes_queue.go
+++ b/queue/bytes_queue.go
@@ -14,9 +14,10 @@ const (
 )
 
 var (
-	errEmptyQueue       = &queueError{"Empty queue"}
+	errEmptyQueue       = &queueError{"Queue is empty."}
 	errInvalidIndex     = &queueError{"Index must be greater than zero. Invalid index."}
 	errIndexOutOfBounds = &queueError{"Index out of range"}
+	errFullQueue        = &queueError{"Queue is full. Maximum size limit reached."}
 )
 
 // BytesQueue is a non-thread safe queue type of fifo based on bytes array.
@@ -92,7 +93,7 @@ func (q *BytesQueue) Push(data []byte) (int, error) {
 		if q.canInsertBeforeHead(neededSize) {
 			q.tail = leftMarginIndex
 		} else if q.capacity+neededSize >= q.maxCapacity && q.maxCapacity > 0 {
-			return -1, &queueError{"Full queue. Maximum size limit reached."}
+			return -1, errFullQueue
 		} else {
 			q.allocateAdditionalMemory(neededSize)
 		}

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -20,7 +20,7 @@ func TestPushAndPop(t *testing.T) {
 	_, err := queue.Pop()
 
 	// then
-	assertEqual(t, "Empty queue", err.Error())
+	assertEqual(t, "Queue is empty.", err.Error())
 
 	// when
 	queue.Push(entry)
@@ -56,7 +56,7 @@ func TestPeek(t *testing.T) {
 	err2 := queue.peekCheckErr(queue.head)
 	// then
 	assertEqual(t, err, err2)
-	assertEqual(t, "Empty queue", err.Error())
+	assertEqual(t, "Queue is empty.", err.Error())
 	assertEqual(t, 0, len(read))
 
 	// when
@@ -113,7 +113,7 @@ func TestReset(t *testing.T) {
 	read, err := queue.Peek()
 
 	// then
-	assertEqual(t, "Empty queue", err.Error())
+	assertEqual(t, "Queue is empty.", err.Error())
 	assertEqual(t, 0, len(read))
 
 	// when
@@ -129,7 +129,7 @@ func TestReset(t *testing.T) {
 	read, err = queue.Peek()
 
 	// then
-	assertEqual(t, "Empty queue", err.Error())
+	assertEqual(t, "Queue is empty.", err.Error())
 	assertEqual(t, 0, len(read))
 }
 
@@ -382,7 +382,7 @@ func TestGetEntryFromEmptyQueue(t *testing.T) {
 	// then
 	assertEqual(t, err, err2)
 	assertEqual(t, []byte(nil), result)
-	assertEqual(t, "Empty queue", err.Error())
+	assertEqual(t, "Queue is empty.", err.Error())
 }
 
 func TestMaxSizeLimit(t *testing.T) {
@@ -399,7 +399,7 @@ func TestMaxSizeLimit(t *testing.T) {
 
 	// then
 	assertEqual(t, 50, capacity)
-	assertEqual(t, "Full queue. Maximum size limit reached.", err.Error())
+	assertEqual(t, "Queue is full. Maximum size limit reached.", err.Error())
 	assertEqual(t, blob('a', 25), pop(queue))
 	assertEqual(t, blob('b', 5), pop(queue))
 }


### PR DESCRIPTION
Per [this issue](https://github.com/allegro/bigcache/issues/400). Added new error type and adjusted the tests accordingly.