### PR TITLE
Add ResetKeyMetadata method to resets per-key metadata.

### DIFF
--- a/bigcache.go
+++ b/bigcache.go
@@ -188,6 +188,14 @@ func (c *BigCache) ResetStats() error {
 	return nil
 }
 
+// ResetKeyMetadata resets per-key metadata
+func (c *BigCache) ResetKeyMetadata() error {
+	for _, shard := range c.shards {
+		shard.resetKeyMetadata(c.config)
+	}
+	return nil
+}
+
 // Len computes the number of entries in the cache.
 func (c *BigCache) Len() int {
 	var len int

--- a/shard.go
+++ b/shard.go
@@ -359,6 +359,12 @@ func (s *cacheShard) resetStats() {
 	s.lock.Unlock()
 }
 
+func (s *cacheShard) resetKeyMetadata(config Config) {
+	s.lock.Lock()
+	s.hashmapStats = make(map[uint64]uint32, config.initialShardSize())
+	s.lock.Unlock()
+}
+
 func (s *cacheShard) len() int {
 	s.lock.RLock()
 	res := len(s.hashmap)


### PR DESCRIPTION
Add `ResetKeyMetadata` Method to Clear Per-Key Request Counts
This PR introduces a `ResetKeyMetadata` method to `BigCache`, allowing users to reset per-key metadata such as request counts.
Similar to the existing `Reset` and `ResetStats` methods, `ResetKeyMetadata` helps clean up accumulated request statistics without affecting cached entries.

This is useful for applications that need to periodically clear usage metrics while retaining cache data.

**Summary of changes:**

- Added `BigCache.ResetKeyMetadata()` and `cacheShard.resetKeyMetadata()` to clear per-key request counts.
- Ensures thread safety by locking shards during reset.