### PR TITLE
fix readme: missing import dependency library

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Requires Go 1.12 or newer.
 
 ```go
 import (
-	"fmt"
 	"context"
+	"fmt"
+	"time"
 	"github.com/allegro/bigcache/v3"
 )
 
@@ -32,7 +33,10 @@ allocation can be avoided in that way.
 
 ```go
 import (
+	"context"
+	"fmt"
 	"log"
+	"time"
 
 	"github.com/allegro/bigcache/v3"
 )


### PR DESCRIPTION
The usage case is missing the imported dependent library In the README.md ,For experienced developers, it may not be a problem, but for beginners, it can be confusing.