### PR TITLE
Optimize map capacity allocation during shard initialization. #419

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -437,9 +437,13 @@ func initNewShard(config Config, callback onRemoveCallback, clock clock) *cacheS
 	if maximumShardSizeInBytes > 0 && bytesQueueInitialCapacity > maximumShardSizeInBytes {
 		bytesQueueInitialCapacity = maximumShardSizeInBytes
 	}
+	var hashmapStatsCapacity int
+	if config.StatsEnabled {
+		hashmapStatsCapacity = config.initialShardSize()
+	}
 	return &cacheShard{
 		hashmap:      make(map[uint64]uint64, config.initialShardSize()),
-		hashmapStats: make(map[uint64]uint32, config.initialShardSize()),
+		hashmapStats: make(map[uint64]uint32, hashmapStatsCapacity),
 		entries:      *queue.NewBytesQueue(bytesQueueInitialCapacity, maximumShardSizeInBytes, config.Verbose),
 		entryBuffer:  make([]byte, config.MaxEntrySize+headersSizeInBytes),
 		onRemove:     callback,


### PR DESCRIPTION
If StatsEnabled is configured as false, No need to initialize the capacity for hashmapStats.
This is because the data is not used in subsequent processes, resulting in the allocation of invalid memory space. 