### PR TITLE
fix(shard): defer shard lock unlock so panics inside eviction do not strand writers

### DIFF
--- a/shard.go
+++ b/shard.go
@@ -121,6 +121,14 @@ func (s *cacheShard) set(key string, hashedKey uint64, entry []byte) error {
 	currentTimestamp := uint64(s.clock.Epoch())
 
 	s.lock.Lock()
+	// Hold the shard lock with defer so that a panic deeper in
+	// readEntry / onRemove / providedOnRemoveWithReason (e.g. a
+	// makeslice-len-out-of-range from a corrupted entry) does not
+	// leave the lock permanently held. Previously, a panic during
+	// onEvict would tear down the goroutine before the manual
+	// Unlock below could run, and every subsequent writer on the
+	// same shard blocked forever (#401).
+	defer s.lock.Unlock()
 
 	if previousIndex := s.hashmap[hashedKey]; previousIndex != 0 {
 		if previousEntry, err := s.entries.Get(int(previousIndex)); err == nil {
@@ -141,11 +149,9 @@ func (s *cacheShard) set(key string, hashedKey uint64, entry []byte) error {
 	for {
 		if index, err := s.entries.Push(w); err == nil {
 			s.hashmap[hashedKey] = uint64(index)
-			s.lock.Unlock()
 			return nil
 		}
 		if s.removeOldestEntry(NoSpace) != nil {
-			s.lock.Unlock()
 			return errors.New("entry is bigger than max shard size")
 		}
 	}
@@ -199,15 +205,17 @@ func (s *cacheShard) setWrappedEntryWithoutLock(currentTimestamp uint64, w []byt
 
 func (s *cacheShard) append(key string, hashedKey uint64, entry []byte) error {
 	s.lock.Lock()
+	// Same lock-hygiene fix as set(): hold the lock across the full
+	// body so a panic deeper in readEntry / onEvict / etc. cannot
+	// strand the shard in a permanently locked state (#401).
+	defer s.lock.Unlock()
+
 	wrappedEntry, err := s.getValidWrapEntry(key, hashedKey)
 
 	if err == ErrEntryNotFound {
-		err = s.addNewWithoutLock(key, hashedKey, entry)
-		s.lock.Unlock()
-		return err
+		return s.addNewWithoutLock(key, hashedKey, entry)
 	}
 	if err != nil {
-		s.lock.Unlock()
 		return err
 	}
 
@@ -215,10 +223,7 @@ func (s *cacheShard) append(key string, hashedKey uint64, entry []byte) error {
 
 	w := appendToWrappedEntry(currentTimestamp, wrappedEntry, entry, &s.entryBuffer)
 
-	err = s.setWrappedEntryWithoutLock(currentTimestamp, w, hashedKey)
-	s.lock.Unlock()
-
-	return err
+	return s.setWrappedEntryWithoutLock(currentTimestamp, w, hashedKey)
 }
 
 func (s *cacheShard) del(hashedKey uint64) error {


### PR DESCRIPTION
## What

Fixes #401.

`cacheShard.set` and `cacheShard.append` acquired `s.lock` with explicit `s.lock.Unlock()` calls along each return path. Any panic fired between the `Lock()` and the first `Unlock()` - for example the `makeslice: len out of range` the user hit inside `readEntry` / `providedOnRemoveWithReason` during an `onEvict` on a corrupted entry - unwound through the deferred nothing and left the shard permanently write-locked. Every subsequent `Set` / `Append` / `Delete` on that shard's key space then blocked forever while the rest of the app kept running, producing the hang that manifests as 'cache seems deadlocked' in production.

## Fix

Acquire the lock at the top of each function and release it with `defer` so that a panic inside the eviction / serialization path is still caught by any higher-level recover, but the shard is always unlocked as the goroutine unwinds. Removed the redundant manual `Unlock` calls along the existing return sites.

Runtime hot-path is functionally unchanged: the defer adds one mov/call per `Set` compared to zero, negligible next to the map + queue work on either side.

## Verification

Locally on macOS, go 1.26.2:
- `gofmt -s -l shard.go`: clean
- `go vet ./...`: clean
- `go test -race -count=1 -short -run 'TestCacheSet|TestCacheGet|TestCacheLen|TestCacheCapacity|TestCacheInitialCapacity|TestCacheDel' ./...`: pass

Note on `TestCacheReset`: this test fails on unmodified master as well (`expected: int(1337) actual: int(725)`) and looks pre-existing / flaky - definitely not a regression from this change. Happy to investigate separately if desired.

Closes #401