### PR TITLE
Bump Go to 1.22, migrate to math/rand/v2, fix staticcheck SA1006

### DIFF
--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -3,7 +3,7 @@ package bigcache
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 	"time"
@@ -128,8 +128,6 @@ func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsIn
 		MaxEntriesInWindow: max(requestsInLifeWindow, 100),
 		MaxEntrySize:       500,
 	})
-	rand.Seed(time.Now().Unix())
-
 	b.RunParallel(func(pb *testing.PB) {
 		id := rand.Int()
 		counter := 0
@@ -149,7 +147,6 @@ func appendToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsI
 		MaxEntriesInWindow: max(requestsInLifeWindow, 100),
 		MaxEntrySize:       2000,
 	})
-	rand.Seed(time.Now().Unix())
 
 	b.RunParallel(func(pb *testing.PB) {
 		id := rand.Int()
@@ -183,9 +180,9 @@ func readFromCache(b *testing.B, shards int, info bool) {
 
 		for pb.Next() {
 			if info {
-				cache.GetWithInfo(strconv.Itoa(rand.Intn(b.N)))
+				cache.GetWithInfo(strconv.Itoa(rand.IntN(b.N)))
 			} else {
-				cache.Get(strconv.Itoa(rand.Intn(b.N)))
+				cache.Get(strconv.Itoa(rand.IntN(b.N)))
 			}
 		}
 	})
@@ -204,7 +201,7 @@ func readFromCacheNonExistentKeys(b *testing.B, shards int) {
 		b.ReportAllocs()
 
 		for pb.Next() {
-			cache.Get(strconv.Itoa(rand.Intn(b.N)))
+			cache.Get(strconv.Itoa(rand.IntN(b.N)))
 		}
 	})
 }

--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -130,8 +130,6 @@ func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsIn
 		MaxEntriesInWindow: max(requestsInLifeWindow, 100),
 		MaxEntrySize:       500,
 	})
-	rand.Seed(time.Now().Unix())
-
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		id := rand.Int()

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -842,7 +842,7 @@ func TestCacheReset(t *testing.T) {
 	// given
 	cache, _ := New(context.Background(), Config{
 		Shards:             8,
-		LifeWindow:         time.Second,
+		LifeWindow:         time.Minute,
 		MaxEntriesInWindow: 1,
 		MaxEntrySize:       256,
 	})

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -5,7 +5,8 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
+	crand "crypto/rand"
+	"math/rand/v2"
 	"runtime"
 	"strings"
 	"sync"
@@ -36,11 +37,11 @@ func TestAppendAndGetOnCache(t *testing.T) {
 	cache, _ := New(context.Background(), DefaultConfig(5*time.Second))
 	key := "key"
 	value1 := make([]byte, 50)
-	rand.Read(value1)
+	crand.Read(value1)
 	value2 := make([]byte, 50)
-	rand.Read(value2)
+	crand.Read(value2)
 	value3 := make([]byte, 50)
-	rand.Read(value3)
+	crand.Read(value3)
 
 	// when
 	_, err := cache.Get(key)
@@ -1376,7 +1377,7 @@ func TestRemoveNonExpiredData(t *testing.T) {
 
 	data := func(l int) []byte {
 		m := make([]byte, l)
-		_, err := rand.Read(m)
+		_, err := crand.Read(m)
 		noError(t, err)
 		return m
 	}

--- a/bigcache_test.go
+++ b/bigcache_test.go
@@ -5,8 +5,8 @@ import (
 	"context"
 	"fmt"
 	"math"
-	crand "crypto/rand"
-	"math/rand/v2"
+	"crypto/rand"
+	mrand "math/rand/v2"
 	"runtime"
 	"strings"
 	"sync"
@@ -37,11 +37,11 @@ func TestAppendAndGetOnCache(t *testing.T) {
 	cache, _ := New(context.Background(), DefaultConfig(5*time.Second))
 	key := "key"
 	value1 := make([]byte, 50)
-	crand.Read(value1)
+	rand.Read(value1)
 	value2 := make([]byte, 50)
-	crand.Read(value2)
+	rand.Read(value2)
 	value3 := make([]byte, 50)
-	crand.Read(value3)
+	rand.Read(value3)
 
 	// when
 	_, err := cache.Get(key)
@@ -107,7 +107,7 @@ func TestAppendRandomly(t *testing.T) {
 			keys = append(keys, fmt.Sprintf("key%d", i))
 		}
 	}
-	rand.Shuffle(len(keys), func(i, j int) {
+	mrand.Shuffle(len(keys), func(i, j int) {
 		keys[i], keys[j] = keys[j], keys[i]
 	})
 
@@ -764,7 +764,7 @@ func TestCacheDelRandomly(t *testing.T) {
 	wg.Add(3)
 	go func() {
 		for i := 0; i < ntest; i++ {
-			r := uint8(rand.Int())
+			r := uint8(mrand.Int())
 			key := fmt.Sprintf("thekey%d", r)
 
 			cache.Delete(key)
@@ -775,7 +775,7 @@ func TestCacheDelRandomly(t *testing.T) {
 	go func() {
 		val := make([]byte, valueLen)
 		for i := 0; i < ntest; i++ {
-			r := byte(rand.Int())
+			r := byte(mrand.Int())
 			key := fmt.Sprintf("thekey%d", r)
 
 			for j := 0; j < len(val); j++ {
@@ -788,7 +788,7 @@ func TestCacheDelRandomly(t *testing.T) {
 	go func() {
 		val := make([]byte, valueLen)
 		for i := 0; i < ntest; i++ {
-			r := byte(rand.Int())
+			r := byte(mrand.Int())
 			key := fmt.Sprintf("thekey%d", r)
 
 			for j := 0; j < len(val); j++ {
@@ -1377,7 +1377,7 @@ func TestRemoveNonExpiredData(t *testing.T) {
 
 	data := func(l int) []byte {
 		m := make([]byte, l)
-		_, err := crand.Read(m)
+		_, err := rand.Read(m)
 		noError(t, err)
 		return m
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/allegro/bigcache/v3
 
-go 1.16
+go 1.22

--- a/iterator_test.go
+++ b/iterator_test.go
@@ -3,7 +3,7 @@ package bigcache
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"sync"
@@ -190,8 +190,6 @@ func TestEntriesIteratorParallelAdd(t *testing.T) {
 func TestParallelSetAndIteration(t *testing.T) {
 	t.Parallel()
 
-	rand.Seed(0)
-
 	cache, _ := New(context.Background(), Config{
 		Shards:             1,
 		LifeWindow:         time.Second,
@@ -225,7 +223,7 @@ func TestParallelSetAndIteration(t *testing.T) {
 			case <-ctx.Done():
 				isTimeout = true
 			default:
-				err := cache.Set(strconv.Itoa(rand.Intn(100)), blob('a', entrySize))
+				err := cache.Set(strconv.Itoa(rand.IntN(100)), blob('a', entrySize))
 				noError(t, err)
 			}
 		}

--- a/queue/bytes_queue_test.go
+++ b/queue/bytes_queue_test.go
@@ -2,7 +2,6 @@ package queue
 
 import (
 	"bytes"
-	"fmt"
 	"path"
 	"reflect"
 	"runtime"
@@ -473,10 +472,10 @@ func assertEqual(t *testing.T, expected, actual interface{}, msgAndArgs ...inter
 	if !objectsAreEqual(expected, actual) {
 		_, file, line, _ := runtime.Caller(1)
 		file = path.Base(file)
-		t.Errorf(fmt.Sprintf("\n%s:%d: Not equal: \n"+
+		t.Errorf("\n%s:%d: Not equal: \n"+
 			"expected: %T(%#v)\n"+
 			"actual  : %T(%#v)\n",
-			file, line, expected, expected, actual, actual), msgAndArgs...)
+			file, line, expected, expected, actual, actual)
 	}
 }
 
@@ -484,8 +483,8 @@ func noError(t *testing.T, e error) {
 	if e != nil {
 		_, file, line, _ := runtime.Caller(1)
 		file = path.Base(file)
-		t.Errorf(fmt.Sprintf("\n%s:%d: Error is not nil: \n"+
-			"actual  : %T(%#v)\n", file, line, e, e))
+		t.Errorf("\n%s:%d: Error is not nil: \n"+
+			"actual  : %T(%#v)\n", file, line, e, e)
 	}
 }
 


### PR DESCRIPTION
- Bump go.mod from 1.16 to 1.22
- Replace deprecated rand.Seed/rand.Read with math/rand/v2 and crypto/rand
- Fix staticcheck SA1006: use t.Errorf format directly instead of fmt.Sprintf