### PR TITLE
Fixed `go test -race -bench=. .` when running in parallel systems to prevent data races

### DIFF
--- a/bigcache_bench_test.go
+++ b/bigcache_bench_test.go
@@ -93,11 +93,13 @@ func BenchmarkIterateOverCache(b *testing.B) {
 				cache.Set(fmt.Sprintf("key-%d", i), m)
 			}
 
+			b.ReportAllocs()
 			b.ResetTimer()
-			it := cache.Iterator()
 
 			b.RunParallel(func(pb *testing.PB) {
-				b.ReportAllocs()
+				// EntryInfoIterator is a stateful cursor intended to be used by a single goroutine at a time.
+				// We instantiate a new iterator for each parallel goroutine to prevent data races.
+				it := cache.Iterator()
 
 				for pb.Next() {
 					if it.SetNext() {
@@ -130,11 +132,11 @@ func writeToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsIn
 	})
 	rand.Seed(time.Now().Unix())
 
+	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		id := rand.Int()
 		counter := 0
 
-		b.ReportAllocs()
 		for pb.Next() {
 			cache.Set(fmt.Sprintf("key-%d-%d", id, counter), message)
 			counter = counter + 1
@@ -151,11 +153,11 @@ func appendToCache(b *testing.B, shards int, lifeWindow time.Duration, requestsI
 	})
 	rand.Seed(time.Now().Unix())
 
+	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {
 		id := rand.Int()
 		counter := 0
 
-		b.ReportAllocs()
 		for pb.Next() {
 			key := fmt.Sprintf("key-%d-%d", id, counter)
 			for j := 0; j < 7; j++ {
@@ -176,11 +178,10 @@ func readFromCache(b *testing.B, shards int, info bool) {
 	for i := 0; i < b.N; i++ {
 		cache.Set(strconv.Itoa(i), message)
 	}
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		b.ReportAllocs()
-
 		for pb.Next() {
 			if info {
 				cache.GetWithInfo(strconv.Itoa(rand.Intn(b.N)))
@@ -198,11 +199,10 @@ func readFromCacheNonExistentKeys(b *testing.B, shards int) {
 		MaxEntriesInWindow: max(b.N, 100),
 		MaxEntrySize:       500,
 	})
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {
-		b.ReportAllocs()
-
 		for pb.Next() {
 			cache.Get(strconv.Itoa(rand.Intn(b.N)))
 		}


### PR DESCRIPTION
## Fix data races in benchmark test suite when running with `-race`

### Summary
Fixes data races flagged when running `go test -race -bench=.` in `bigcache_bench_test.go`.

### Root Cause & Changes

1. **Moved `b.ReportAllocs()` outside `b.RunParallel`**
   - `b.ReportAllocs()` mutates non-thread-safe internal fields on `*testing.B`.
   - Calling `b.ReportAllocs()` inside `b.RunParallel(...)` caused concurrent write data races on `*testing.B` across parallel worker goroutines.
   - **Fix**: Relocated `b.ReportAllocs()` to the benchmark setup phase outside `b.RunParallel` across `writeToCache`, `appendToCache`, `readFromCache`, `readFromCacheNonExistentKeys`, and `BenchmarkIterateOverCache`.

2. **Isolated `EntryInfoIterator` instances per worker goroutine**
   - `EntryInfoIterator` is a stateful cursor. While `SetNext()` locks internal state during element advancement, it releases the lock before returning, allowing `Value()` to read state without holding the lock.
   - Sharing a single `Iterator` instance across multiple parallel goroutines inside `b.RunParallel` caused data races between concurrent `SetNext()` writes and `Value()` reads.
   - **Fix**: Moved `it := cache.Iterator()` inside the `b.RunParallel` loop so each worker goroutine operates on its own iterator instance, and added a documentation comment explaining iterator thread isolation.

### Verification
Ran benchmarks with the Go race detector enabled:
```bash
go test -race -bench=. .

